### PR TITLE
Automate pkg shell integration during postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ For the first packaged release (`0.0.1`):
 
 - the packaged CLI still expects **Node 20+** on the target Mac
 - the installer lays down the CLI payload plus both apps
-- after installation, run `goto-install-shell` to enable shell `cd` integration
+- the installer attempts shell integration automatically for the logged-in macOS user
+- if that step is skipped, run `goto-install-shell` manually
 - remove the packaged install later with `sudo goto-uninstall` (`--purge` also deletes `~/.goto` and `~/.goto-settings`)
 
 If Apple signing/notarization secrets are unavailable, the GitHub workflow falls back to an **unsigned prerelease** package: `goto-<version>-unsigned.pkg`.

--- a/docs/distribution-checklist.md
+++ b/docs/distribution-checklist.md
@@ -83,7 +83,7 @@ One `.pkg` installs all of the following:
    - Install an easy command such as:
      - `/usr/local/bin/goto-install-shell`
    - That helper should call the packaged `install-shell.sh` against the installed prefix.
-   - Prefer this over silently mutating dotfiles from a root installer process.
+   - Use the pkg `postinstall` step to invoke that helper as the logged-in macOS user so shell dotfiles keep the correct ownership.
 
 ## Distribution checklist
 
@@ -93,8 +93,8 @@ One `.pkg` installs all of the following:
 - [x] Choose the permanent CLI install prefix (`/usr/local/lib/goto`)
 - [x] Keep **Node 20+** as the v1 packaged-distribution prerequisite
 - [ ] Decide whether the installer will:
-  - [x] only install assets, then ask the user to run shell setup
-  - [ ] or also perform shell setup automatically for the current user
+  - [ ] only install assets, then ask the user to run shell setup
+  - [x] or also perform shell setup automatically for the current user
 
 **Recommendation:** keep Node 20+ as a documented prerequisite for the first packaged release. It is the lowest-effort path for this developer-focused tool.
 
@@ -121,7 +121,8 @@ One `.pkg` installs all of the following:
   - [x] registers the Finder Sync extension with `pluginkit`
   - [x] restarts Finder if needed
   - [ ] optionally opens Extensions settings
-  - [x] prints the shell setup next step clearly
+  - [x] runs shell setup automatically for the logged-in user when possible
+  - [x] prints a manual shell setup fallback clearly
 
 ### Phase 3 — Deferred public-release track (signing and notarization)
 

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -58,25 +58,7 @@ if [[ -n "${GOTO_CODESIGN_IDENTITY:-}" ]]; then
   codesign --verify --strict --verbose=2 "$menu_app_path"
 fi
 
-cat > "$scripts_root/postinstall" <<'POSTINSTALL'
-#!/bin/sh
-set -e
-
-FINDER_APP="/Applications/GotoFinder.app"
-EXTENSION_PATH="$FINDER_APP/Contents/PlugIns/GotoFinderSync.appex"
-
-if [ -d "$EXTENSION_PATH" ]; then
-  /usr/bin/pluginkit -a "$EXTENSION_PATH" >/dev/null || true
-  /usr/bin/pluginkit -e use -i "dev.goto.finder.findersync" >/dev/null 2>&1 || true
-fi
-
-/usr/bin/killall Finder >/dev/null 2>&1 || true
-
-echo
-echo "goto installed."
-echo "Run 'goto-install-shell' to enable shell cd integration."
-echo "If Finder Sync is disabled, re-enable goto in System Settings > Extensions > Finder Extensions."
-POSTINSTALL
+cp "$REPO_ROOT/scripts/pkg-postinstall.sh" "$scripts_root/postinstall"
 chmod +x "$scripts_root/postinstall"
 
 pkgbuild_cmd=(

--- a/scripts/pkg-postinstall.sh
+++ b/scripts/pkg-postinstall.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+
+FINDER_APP="${GOTO_FINDER_APP:-/Applications/GotoFinder.app}"
+EXTENSION_PATH="$FINDER_APP/Contents/PlugIns/GotoFinderSync.appex"
+EXTENSION_ID="${GOTO_EXTENSION_ID:-dev.goto.finder.findersync}"
+INSTALL_SHELL_BIN="${GOTO_INSTALL_SHELL_BIN:-/usr/local/bin/goto-install-shell}"
+PLUGINKIT_BIN="${GOTO_PLUGINKIT_BIN:-/usr/bin/pluginkit}"
+KILLALL_BIN="${GOTO_KILLALL_BIN:-/usr/bin/killall}"
+STAT_BIN="${GOTO_STAT_BIN:-/usr/bin/stat}"
+SU_BIN="${GOTO_SU_BIN:-/usr/bin/su}"
+console_user="${GOTO_CONSOLE_USER:-$("$STAT_BIN" -f %Su /dev/console 2>/dev/null || true)}"
+
+enable_finder_extension() {
+  if [ -d "$EXTENSION_PATH" ]; then
+    "$PLUGINKIT_BIN" -a "$EXTENSION_PATH" >/dev/null || true
+    "$PLUGINKIT_BIN" -e use -i "$EXTENSION_ID" >/dev/null 2>&1 || true
+  fi
+
+  "$KILLALL_BIN" Finder >/dev/null 2>&1 || true
+}
+
+install_shell_integration() {
+  if [ ! -x "$INSTALL_SHELL_BIN" ]; then
+    return 1
+  fi
+
+  case "$console_user" in
+    ""|root|loginwindow)
+      return 1
+      ;;
+  esac
+
+  "$SU_BIN" -l "$console_user" -c "'$INSTALL_SHELL_BIN'" >/dev/null 2>&1
+}
+
+enable_finder_extension
+
+shell_integration_status="manual"
+if install_shell_integration; then
+  shell_integration_status="auto"
+fi
+
+echo
+echo "goto installed."
+if [ "$shell_integration_status" = "auto" ]; then
+  echo "Shell integration was installed for $console_user. Open a new shell to use 'goto' cd integration."
+else
+  echo "Run 'goto-install-shell' to enable shell cd integration."
+fi
+echo "If Finder Sync is disabled, re-enable goto in System Settings > Extensions > Finder Extensions."

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -78,6 +78,101 @@ test('install-shell script writes the bash source block exactly once', async () 
   assert.match(contents, /goto\.bash/);
 });
 
+test('pkg postinstall runs shell integration as the logged-in user', async () => {
+  const homeDir = await createTempDir('goto-postinstall-home-');
+  const fakeBinDir = await createTempDir('goto-postinstall-bin-');
+  const scriptPath = path.join(projectRoot, 'scripts/pkg-postinstall.sh');
+  const installScriptPath = path.join(projectRoot, 'scripts/install-shell.sh');
+  const rcFile = path.join(homeDir, '.zshrc');
+  const statPath = path.join(fakeBinDir, 'stat');
+  const suPath = path.join(fakeBinDir, 'su');
+  const pluginkitPath = path.join(fakeBinDir, 'pluginkit');
+  const killallPath = path.join(fakeBinDir, 'killall');
+  const suLogPath = path.join(fakeBinDir, 'su.log');
+  const finderAppDir = path.join(await createTempDir('goto-finder-app-'), 'GotoFinder.app');
+  const extensionPath = path.join(finderAppDir, 'Contents', 'PlugIns', 'GotoFinderSync.appex');
+
+  await fs.mkdir(extensionPath, { recursive: true });
+
+  await writeExecutable(
+    statPath,
+    `#!/bin/sh
+printf '%s\\n' "test-user"
+`
+  );
+  await writeExecutable(
+    suPath,
+    `#!/bin/sh
+printf '%s\\n' "$*" >> "${suLogPath}"
+user=""
+command=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -l)
+      user="$2"
+      shift 2
+      ;;
+    -c)
+      command="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+HOME="${homeDir}" SHELL="/bin/zsh" USER="$user" LOGNAME="$user" /bin/sh -c "$command"
+`
+  );
+  await writeExecutable(
+    pluginkitPath,
+    `#!/bin/sh
+exit 0
+`
+  );
+  await writeExecutable(
+    killallPath,
+    `#!/bin/sh
+exit 0
+`
+  );
+
+  const firstRun = await runProcess('sh', [scriptPath], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      GOTO_FINDER_APP: finderAppDir,
+      GOTO_INSTALL_SHELL_BIN: installScriptPath,
+      GOTO_PLUGINKIT_BIN: pluginkitPath,
+      GOTO_KILLALL_BIN: killallPath,
+      GOTO_STAT_BIN: statPath,
+      GOTO_SU_BIN: suPath,
+    },
+  });
+  const secondRun = await runProcess('sh', [scriptPath], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      GOTO_FINDER_APP: finderAppDir,
+      GOTO_INSTALL_SHELL_BIN: installScriptPath,
+      GOTO_PLUGINKIT_BIN: pluginkitPath,
+      GOTO_KILLALL_BIN: killallPath,
+      GOTO_STAT_BIN: statPath,
+      GOTO_SU_BIN: suPath,
+    },
+  });
+
+  const contents = await fs.readFile(rcFile, 'utf8');
+  const matches = contents.match(/source ".*goto\.zsh"/g) || [];
+  const suLog = await fs.readFile(suLogPath, 'utf8');
+
+  assert.equal(firstRun.code, 0);
+  assert.equal(secondRun.code, 0);
+  assert.equal(matches.length, 1);
+  assert.match(firstRun.stdout, /Shell integration was installed for test-user/);
+  assert.match(suLog, /-l test-user -c/);
+});
+
 test('uninstall script removes packaged files and preserves user data by default', async () => {
   const homeDir = await createTempDir('goto-uninstall-home-');
   const installRoot = await createTempDir('goto-uninstall-install-');


### PR DESCRIPTION
## Summary
- move the pkg postinstall logic into a tracked script instead of generating it inline
- run installed goto into /Users/inchan/.zshrc under the logged-in macOS user so shell RC files keep the right ownership
- add a regression test for the postinstall flow and update packaged-install docs

## Testing
- ✔ help prints usage to stdout and exits successfully (159.048213ms)
✔ version prints to stdout (142.610067ms)
✔ unknown arguments fail with usage exit code and stderr output (113.81044ms)
✔ select without saved projects fails cleanly without stdout noise (100.508304ms)
✔ goto -a uses the current directory when no path is provided (253.388962ms)
✔ goto -A adds only direct child directories from the target root (272.099886ms)
✔ goto --children defaults to the current directory (320.578625ms)
✔ goto -A reports already-saved child directories without duplicating them (483.870762ms)
✔ duplicate add is idempotent and keeps stdout/stderr contract clean (299.021535ms)
✔ goto -r removes the current directory when no path is provided (284.395298ms)
✔ remove of a non-registered path is a clear no-op (104.138652ms)
✔ invalid add path fails with stderr output and no registry writes (122.426424ms)
✔ select with saved projects but no tty reports the shell-integration requirement (241.407498ms)
✔ test/helpers.js (356.65098ms)
✔ the direct executable path works from the repository (160.992111ms)
✔ install-shell script writes the zsh source block exactly once (91.982417ms)
✔ install-shell script writes the bash source block exactly once (96.024763ms)
✔ pkg postinstall runs shell integration as the logged-in user (1011.941614ms)
✔ bash and zsh wrappers pass through registry management commands (359.1089ms)
✔ bash and zsh wrappers only cd on successful no-arg selection (116.285145ms)
✔ bash and zsh wrappers leave the directory unchanged on cancel (218.399394ms)
✔ writeRegistry de-duplicates while preserving the existing order (111.483388ms)
✔ addRegistryEntry stores canonical absolute paths and prevents duplicates (102.571797ms)
✔ removeRegistryEntry removes stored entries and reports no-op for missing ones (22.165658ms)
✔ promoteRegistryEntry moves the selected project to the front (14.140839ms)
ℹ tests 25
ℹ suites 0
ℹ pass 25
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 3011.093534
- 

Closes #1