### PR TITLE
Add goto-uninstall for packaged installs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Three independent packages for macOS project jumping — each installable separa
 ## Build & test commands
 
 ```bash
-node --test                          # 24 JS tests — must pass before changes
+node --test                          # 26 JS tests — must pass before changes
 swift test -c debug                  # 38 Swift tests — must pass before changes
 swift build -c release               # Build SPM targets
 scripts/build-menu-bar-app.sh        # Build goto-menubar (.app)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ For the first packaged release (`0.0.1`):
 - the packaged CLI still expects **Node 20+** on the target Mac
 - the installer lays down the CLI payload plus both apps
 - after installation, run `goto-install-shell` to enable shell `cd` integration
+- remove the packaged install later with `sudo goto-uninstall` (`--purge` also deletes `~/.goto` and `~/.goto-settings`)
 
 If Apple signing/notarization secrets are unavailable, the GitHub workflow falls back to an **unsigned prerelease** package: `goto-<version>-unsigned.pkg`.
 Users can still install it, but macOS will require manual approval in **Privacy & Security → Open Anyway**.
@@ -148,6 +149,7 @@ The Finder Sync extension runs in a sandbox and communicates with the host app v
 | `run-native-menu-bar.sh` | Build and run the menu bar app in one step |
 | `build-finder.sh` | Build `GotoFinder.app` via `xcodebuild` |
 | `build-pkg.sh` | Build a single installer package containing CLI + menu bar + Finder |
+| `uninstall.sh` | Remove the packaged install from `/Applications` and `/usr/local` |
 | `install-finder.sh` | Build, install to `~/Applications`, register extension |
 | `uninstall-finder.sh` | Remove `~/Applications/GotoFinder.app` and unregister extension |
 | `test-finder.sh` | Install and smoke-test the Finder app |

--- a/docs/distribution-checklist.md
+++ b/docs/distribution-checklist.md
@@ -116,7 +116,7 @@ One `.pkg` installs all of the following:
 - [x] Stage CLI files into the chosen install prefix inside the staging root
 - [x] Stage `GotoMenuBar.app` into `/Applications`
 - [x] Stage `GotoFinder.app` into `/Applications`
-- [x] Stage helper scripts (`goto-install-shell`, optional uninstall helper)
+- [x] Stage helper scripts (`goto-install-shell`, `goto-uninstall`)
 - [x] Add a postinstall script that:
   - [x] registers the Finder Sync extension with `pluginkit`
   - [x] restarts Finder if needed

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -39,10 +39,12 @@ cp -R "$REPO_ROOT/bin" "$cli_root/"
 cp -R "$REPO_ROOT/src" "$cli_root/"
 cp -R "$REPO_ROOT/shell" "$cli_root/"
 cp "$REPO_ROOT/scripts/install-shell.sh" "$cli_root/scripts/install-shell.sh"
-chmod +x "$cli_root/bin/goto.js" "$cli_root/scripts/install-shell.sh"
+cp "$REPO_ROOT/scripts/uninstall.sh" "$cli_root/scripts/uninstall.sh"
+chmod +x "$cli_root/bin/goto.js" "$cli_root/scripts/install-shell.sh" "$cli_root/scripts/uninstall.sh"
 
 ln -sfn "$install_prefix/bin/goto.js" "$cli_bin_root/goto"
 ln -sfn "$install_prefix/scripts/install-shell.sh" "$cli_bin_root/goto-install-shell"
+ln -sfn "$install_prefix/scripts/uninstall.sh" "$cli_bin_root/goto-uninstall"
 
 if [[ -n "${GOTO_CODESIGN_IDENTITY:-}" ]]; then
   printf '==> Signing app bundles\n' >&2

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  goto-uninstall [--purge]
+
+Options:
+  --purge    Also remove ~/.goto and ~/.goto-settings
+  --help     Show this help
+EOF
+}
+
+INSTALL_PREFIX="${GOTO_INSTALL_PREFIX:-/usr/local/lib/goto}"
+BIN_PREFIX="${GOTO_BIN_PREFIX:-/usr/local/bin}"
+MENU_APP_PATH="${GOTO_MENU_APP_PATH:-/Applications/GotoMenuBar.app}"
+FINDER_APP_PATH="${GOTO_FINDER_APP_PATH:-/Applications/GotoFinder.app}"
+EXTENSION_PATH="$FINDER_APP_PATH/Contents/PlugIns/GotoFinderSync.appex"
+EXTENSION_ID="${GOTO_EXTENSION_ID:-dev.goto.finder.findersync}"
+INSTALL_RECEIPT_ID="${GOTO_INSTALL_RECEIPT_ID:-dev.goto.installer}"
+PLUGINKIT_BIN="${GOTO_PLUGINKIT_BIN:-/usr/bin/pluginkit}"
+PKGUTIL_BIN="${GOTO_PKGUTIL_BIN:-/usr/sbin/pkgutil}"
+PKILL_BIN="${GOTO_PKILL_BIN:-/usr/bin/pkill}"
+KILLALL_BIN="${GOTO_KILLALL_BIN:-/usr/bin/killall}"
+DSCL_BIN="${GOTO_DSCL_BIN:-/usr/bin/dscl}"
+STAT_BIN="${GOTO_STAT_BIN:-/usr/bin/stat}"
+purge_user_data=false
+
+while (($# > 0)); do
+  case "$1" in
+    --purge)
+      purge_user_data=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'goto uninstall: unknown option: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ "${GOTO_UNINSTALL_ALLOW_NON_ROOT:-0}" != "1" && "${EUID}" -ne 0 ]]; then
+  printf 'goto uninstall: run with sudo so installed apps and /usr/local payloads can be removed\n' >&2
+  exit 1
+fi
+
+resolve_target_user() {
+  if [[ -n "${GOTO_TARGET_USER:-}" ]]; then
+    printf '%s\n' "$GOTO_TARGET_USER"
+    return
+  fi
+
+  if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+    printf '%s\n' "$SUDO_USER"
+    return
+  fi
+
+  "$STAT_BIN" -f '%Su' /dev/console 2>/dev/null || true
+}
+
+resolve_target_home() {
+  local target_user="$1"
+
+  if [[ -n "${GOTO_TARGET_HOME:-}" ]]; then
+    printf '%s\n' "$GOTO_TARGET_HOME"
+    return
+  fi
+
+  if [[ -z "$target_user" || "$target_user" == "root" || "$target_user" == "loginwindow" ]]; then
+    return
+  fi
+
+  "$DSCL_BIN" . -read "/Users/$target_user" NFSHomeDirectory 2>/dev/null | awk '{print $2}'
+}
+
+remove_shell_integration() {
+  local rc_file="$1"
+  local temp_file
+
+  [[ -f "$rc_file" ]] || return 0
+
+  temp_file="$(mktemp "${TMPDIR:-/tmp}/goto-uninstall.XXXXXX")"
+  awk -v installed_source_prefix="$INSTALL_PREFIX/shell/goto." '
+    $0 == "# >>> goto >>>" {
+      in_block = 1
+      block_count = 1
+      block[block_count] = $0
+      block_matches_install = 0
+      next
+    }
+
+    in_block {
+      block_count++
+      block[block_count] = $0
+
+      if (index($0, installed_source_prefix) > 0) {
+        block_matches_install = 1
+      }
+
+      if ($0 == "# <<< goto <<<") {
+        if (!block_matches_install) {
+          for (i = 1; i <= block_count; i++) {
+            print block[i]
+          }
+        }
+
+        in_block = 0
+        block_count = 0
+        delete block
+      }
+      next
+    }
+
+    index($0, installed_source_prefix) == 0 {
+      print
+    }
+
+    END {
+      if (in_block && !block_matches_install) {
+        for (i = 1; i <= block_count; i++) {
+          print block[i]
+        }
+      }
+    }
+  ' "$rc_file" > "$temp_file"
+  mv "$temp_file" "$rc_file"
+}
+
+target_user="$(resolve_target_user)"
+target_home="$(resolve_target_home "$target_user")"
+registry_path="${GOTO_REGISTRY_PATH:-${target_home:+$target_home/.goto}}"
+settings_path="${GOTO_SETTINGS_PATH:-${target_home:+$target_home/.goto-settings}}"
+
+if [[ -n "$target_home" ]]; then
+  remove_shell_integration "$target_home/.zshrc"
+  remove_shell_integration "$target_home/.bashrc"
+fi
+
+"$PKILL_BIN" -f "$MENU_APP_PATH/Contents/MacOS/" >/dev/null 2>&1 || true
+"$PKILL_BIN" -f "$FINDER_APP_PATH/Contents/MacOS/" >/dev/null 2>&1 || true
+
+"$PLUGINKIT_BIN" -e ignore -i "$EXTENSION_ID" >/dev/null 2>&1 || true
+if [[ -d "$EXTENSION_PATH" ]]; then
+  "$PLUGINKIT_BIN" -r "$EXTENSION_PATH" >/dev/null 2>&1 || true
+fi
+
+rm -rf -- "$MENU_APP_PATH" "$FINDER_APP_PATH" "$INSTALL_PREFIX"
+rm -f -- "$BIN_PREFIX/goto" "$BIN_PREFIX/goto-install-shell" "$BIN_PREFIX/goto-uninstall"
+
+"$PKGUTIL_BIN" --forget "$INSTALL_RECEIPT_ID" >/dev/null 2>&1 || true
+"$KILLALL_BIN" Finder >/dev/null 2>&1 || true
+
+if $purge_user_data; then
+  [[ -n "${registry_path:-}" ]] && rm -f -- "$registry_path"
+  [[ -n "${settings_path:-}" ]] && rm -f -- "$settings_path"
+fi
+
+echo
+echo "goto uninstalled."
+if $purge_user_data; then
+  echo "Removed user data files."
+else
+  echo "Preserved user data files. Re-run with --purge to remove ~/.goto and ~/.goto-settings."
+fi

--- a/test/install-smoke.test.js
+++ b/test/install-smoke.test.js
@@ -78,6 +78,139 @@ test('install-shell script writes the bash source block exactly once', async () 
   assert.match(contents, /goto\.bash/);
 });
 
+test('uninstall script removes packaged files and preserves user data by default', async () => {
+  const homeDir = await createTempDir('goto-uninstall-home-');
+  const installRoot = await createTempDir('goto-uninstall-install-');
+  const appsRoot = await createTempDir('goto-uninstall-apps-');
+  const binRoot = await createTempDir('goto-uninstall-bin-');
+  const fakeBinDir = await createTempDir('goto-uninstall-fakebin-');
+  const scriptPath = path.join(projectRoot, 'scripts/uninstall.sh');
+  const menuAppPath = path.join(appsRoot, 'GotoMenuBar.app');
+  const finderAppPath = path.join(appsRoot, 'GotoFinder.app');
+  const extensionPath = path.join(finderAppPath, 'Contents', 'PlugIns', 'GotoFinderSync.appex');
+  const installPrefix = path.join(installRoot, 'goto');
+  const gotoSymlink = path.join(binRoot, 'goto');
+  const installShellSymlink = path.join(binRoot, 'goto-install-shell');
+  const uninstallSymlink = path.join(binRoot, 'goto-uninstall');
+  const registryPath = path.join(homeDir, '.goto');
+  const settingsPath = path.join(homeDir, '.goto-settings');
+  const zshrcPath = path.join(homeDir, '.zshrc');
+  const bashrcPath = path.join(homeDir, '.bashrc');
+  const pluginkitLogPath = path.join(fakeBinDir, 'pluginkit.log');
+  const pkgutilLogPath = path.join(fakeBinDir, 'pkgutil.log');
+
+  await fs.mkdir(path.join(installPrefix, 'scripts'), { recursive: true });
+  await fs.mkdir(extensionPath, { recursive: true });
+  await fs.writeFile(path.join(installPrefix, 'scripts', 'install-shell.sh'), '#!/bin/sh\n');
+  await writeExecutable(path.join(fakeBinDir, 'pluginkit'), `#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${pluginkitLogPath}\"\n`);
+  await writeExecutable(path.join(fakeBinDir, 'pkgutil'), `#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"${pkgutilLogPath}\"\n`);
+  await writeExecutable(path.join(fakeBinDir, 'pkill'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'killall'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'dscl'), `#!/bin/sh\nprintf 'NFSHomeDirectory: %s\\n' \"${homeDir}\"\n`);
+  await writeExecutable(path.join(fakeBinDir, 'stat'), '#!/bin/sh\nprintf \'%s\\n\' test-user\n');
+  await fs.symlink(path.join(installPrefix, 'bin', 'goto.js'), gotoSymlink).catch(() => {});
+  await fs.symlink(path.join(installPrefix, 'scripts', 'install-shell.sh'), installShellSymlink).catch(() => {});
+  await fs.symlink(scriptPath, uninstallSymlink).catch(() => {});
+  await fs.writeFile(registryPath, '/tmp/project\n');
+  await fs.writeFile(settingsPath, '{"finder":{"enabled":true}}\n');
+  await fs.writeFile(
+    zshrcPath,
+    `# >>> goto >>>\nsource "${installPrefix}/shell/goto.zsh"\n# <<< goto <<<\n# keep me\n# >>> goto >>>\nsource "${projectRoot}/shell/goto.zsh"\n# <<< goto <<<\n`
+  );
+  await fs.writeFile(
+    bashrcPath,
+    `# >>> goto >>>\nsource "${installPrefix}/shell/goto.bash"\n# <<< goto <<<\nexport PATH="$PATH:/tmp"\n`
+  );
+
+  const result = await runProcess('bash', [scriptPath], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      GOTO_UNINSTALL_ALLOW_NON_ROOT: '1',
+      GOTO_INSTALL_PREFIX: installPrefix,
+      GOTO_BIN_PREFIX: binRoot,
+      GOTO_MENU_APP_PATH: menuAppPath,
+      GOTO_FINDER_APP_PATH: finderAppPath,
+      GOTO_PLUGINKIT_BIN: path.join(fakeBinDir, 'pluginkit'),
+      GOTO_PKGUTIL_BIN: path.join(fakeBinDir, 'pkgutil'),
+      GOTO_PKILL_BIN: path.join(fakeBinDir, 'pkill'),
+      GOTO_KILLALL_BIN: path.join(fakeBinDir, 'killall'),
+      GOTO_DSCL_BIN: path.join(fakeBinDir, 'dscl'),
+      GOTO_STAT_BIN: path.join(fakeBinDir, 'stat'),
+      GOTO_TARGET_USER: 'test-user',
+    },
+  });
+
+  const zshContents = await fs.readFile(zshrcPath, 'utf8');
+  const bashContents = await fs.readFile(bashrcPath, 'utf8');
+  const pluginkitLog = await fs.readFile(pluginkitLogPath, 'utf8');
+  const pkgutilLog = await fs.readFile(pkgutilLogPath, 'utf8');
+
+  assert.equal(result.code, 0);
+  await assert.rejects(fs.access(menuAppPath));
+  await assert.rejects(fs.access(finderAppPath));
+  await assert.rejects(fs.access(installPrefix));
+  await assert.rejects(fs.access(gotoSymlink));
+  await assert.rejects(fs.access(installShellSymlink));
+  await assert.rejects(fs.access(uninstallSymlink));
+  assert.match(zshContents, /# keep me/);
+  assert.doesNotMatch(zshContents, new RegExp(`${installPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/shell/goto\\.zsh`));
+  assert.match(zshContents, new RegExp(`${projectRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/shell/goto\\.zsh`));
+  assert.match(bashContents, /export PATH/);
+  assert.doesNotMatch(bashContents, new RegExp(`${installPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/shell/goto\\.bash`));
+  await fs.access(registryPath);
+  await fs.access(settingsPath);
+  assert.match(pluginkitLog, /-e ignore -i dev\.goto\.finder\.findersync/);
+  assert.match(pkgutilLog, /--forget dev\.goto\.installer/);
+  assert.match(result.stdout, /Preserved user data files/);
+});
+
+test('uninstall script removes user data with --purge', async () => {
+  const homeDir = await createTempDir('goto-uninstall-purge-home-');
+  const installRoot = await createTempDir('goto-uninstall-purge-install-');
+  const appsRoot = await createTempDir('goto-uninstall-purge-apps-');
+  const binRoot = await createTempDir('goto-uninstall-purge-bin-');
+  const fakeBinDir = await createTempDir('goto-uninstall-purge-fakebin-');
+  const scriptPath = path.join(projectRoot, 'scripts/uninstall.sh');
+  const installPrefix = path.join(installRoot, 'goto');
+  const registryPath = path.join(homeDir, '.goto');
+  const settingsPath = path.join(homeDir, '.goto-settings');
+
+  await fs.mkdir(installPrefix, { recursive: true });
+  await writeExecutable(path.join(fakeBinDir, 'pluginkit'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'pkgutil'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'pkill'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'killall'), '#!/bin/sh\nexit 0\n');
+  await writeExecutable(path.join(fakeBinDir, 'dscl'), `#!/bin/sh\nprintf 'NFSHomeDirectory: %s\\n' \"${homeDir}\"\n`);
+  await writeExecutable(path.join(fakeBinDir, 'stat'), '#!/bin/sh\nprintf \'%s\\n\' test-user\n');
+  await fs.writeFile(registryPath, '/tmp/project\n');
+  await fs.writeFile(settingsPath, '{"finder":{"enabled":true}}\n');
+
+  const result = await runProcess('bash', [scriptPath, '--purge'], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      GOTO_UNINSTALL_ALLOW_NON_ROOT: '1',
+      GOTO_INSTALL_PREFIX: installPrefix,
+      GOTO_BIN_PREFIX: binRoot,
+      GOTO_MENU_APP_PATH: path.join(appsRoot, 'GotoMenuBar.app'),
+      GOTO_FINDER_APP_PATH: path.join(appsRoot, 'GotoFinder.app'),
+      GOTO_PLUGINKIT_BIN: path.join(fakeBinDir, 'pluginkit'),
+      GOTO_PKGUTIL_BIN: path.join(fakeBinDir, 'pkgutil'),
+      GOTO_PKILL_BIN: path.join(fakeBinDir, 'pkill'),
+      GOTO_KILLALL_BIN: path.join(fakeBinDir, 'killall'),
+      GOTO_DSCL_BIN: path.join(fakeBinDir, 'dscl'),
+      GOTO_STAT_BIN: path.join(fakeBinDir, 'stat'),
+      GOTO_TARGET_USER: 'test-user',
+    },
+  });
+
+  assert.equal(result.code, 0);
+  await assert.rejects(fs.access(registryPath));
+  await assert.rejects(fs.access(settingsPath));
+  assert.match(result.stdout, /Removed user data files/);
+});
+
 test('bash and zsh wrappers pass through registry management commands', async () => {
   const homeDir = await createTempDir();
   const projectDir = await createTempDir();


### PR DESCRIPTION
## Summary
- add a packaged uninstall helper and expose it as 
- remove the pkg-installed apps, symlinks, Finder integration, and only the shell blocks that point at the packaged install prefix
- preserve  and  by default, with  for explicit cleanup

## Testing
- ✔ help prints usage to stdout and exits successfully (220.461899ms)
✔ version prints to stdout (229.922676ms)
✔ unknown arguments fail with usage exit code and stderr output (113.477135ms)
✔ select without saved projects fails cleanly without stdout noise (141.140053ms)
✔ goto -a uses the current directory when no path is provided (413.015805ms)
✔ goto -A adds only direct child directories from the target root (480.181191ms)
✔ goto --children defaults to the current directory (270.082494ms)
✔ goto -A reports already-saved child directories without duplicating them (498.664004ms)
✔ duplicate add is idempotent and keeps stdout/stderr contract clean (268.056185ms)
✔ goto -r removes the current directory when no path is provided (328.553469ms)
✔ remove of a non-registered path is a clear no-op (149.592474ms)
✔ invalid add path fails with stderr output and no registry writes (113.289684ms)
✔ select with saved projects but no tty reports the shell-integration requirement (282.812355ms)
✔ test/helpers.js (134.662901ms)
✔ the direct executable path works from the repository (287.67194ms)
✔ install-shell script writes the zsh source block exactly once (329.634548ms)
✔ install-shell script writes the bash source block exactly once (97.151333ms)
✔ uninstall script removes packaged files and preserves user data by default (225.538903ms)
✔ uninstall script removes user data with --purge (77.057779ms)
✔ bash and zsh wrappers pass through registry management commands (416.095136ms)
✔ bash and zsh wrappers only cd on successful no-arg selection (202.156864ms)
✔ bash and zsh wrappers leave the directory unchanged on cancel (51.504062ms)
✔ writeRegistry de-duplicates while preserving the existing order (120.744532ms)
✔ addRegistryEntry stores canonical absolute paths and prevents duplicates (176.881556ms)
✔ removeRegistryEntry removes stored entries and reports no-op for missing ones (186.923848ms)
✔ promoteRegistryEntry moves the selected project to the front (173.895421ms)
ℹ tests 26
ℹ suites 0
ℹ pass 26
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 3213.392724
- 

Closes #2