### PR TITLE
chore(hermes): add autonomy harness

### DIFF
--- a/.hermes/.gitignore
+++ b/.hermes/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*/__pycache__/
+*.pyc
+
+# Local/generated run artifacts. Templates, schemas, scripts, tests, and docs stay trackable.
+runs/
+events/
+reports/*.md
+state/project-snapshot.json
+derived/current-status.json
+derived/harness-drift-report.json
+derived/harness-check-report.json
+derived/action-preflight.json
+derived/observability-scorecard.json
+derived/workflow-health.json
+derived/readiness-*.json

--- a/.hermes/README.md
+++ b/.hermes/README.md
@@ -1,0 +1,77 @@
+# goto Hermes scaffold
+
+This directory holds project-local Hermes profile and subagent role prompts.
+
+Files:
+- `profile.md` — project default behavior and scope
+- `agents/research.md` — inspect and ground the problem
+- `agents/planner.md` — pick the next small objective
+- `agents/implementer.md` — make the code change
+- `agents/verifier.md` — run tests / dry-runs / mechanical checks
+- `agents/reviewer.md` — assess quality and risks
+
+Current readiness score: 90
+Recommended roles: research, planner, implementer, verifier, reviewer
+
+## Stable harness check
+
+Use the aggregate check first. It is the safest current entry point because it runs validation, snapshot, drift, and readiness together without enabling execution:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe
+```
+
+Expected state on `main`:
+
+```text
+operating_state=stable_observe_only
+observe=pass exit_code=0
+execute=blocked exit_code=10
+require=observe
+```
+
+Use the stricter form when a caller must prove execution readiness:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-execute
+```
+
+Expected state on `main`: same report, but the command exits non-zero because execution is blocked.
+
+Attach a requested action to the same report before doing any work:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --action "read README.md"
+```
+
+The small action gate in `check_harness_ready.py` currently distinguishes:
+
+- `read_only` — observe-safe
+- `repo_write` — execute-only, still subject to readiness gates
+- `user_or_system_side_effect` — manual gate required
+- `scheduler_side_effect` — manual gate required
+- `unknown_action` — fail closed/manual gate required
+
+Current execute hardening:
+
+- unknown readiness modes are blocked
+- execute requires a known git repository and branch
+- execute is blocked on `main`
+- execute is blocked outside allowlisted branch prefixes: `hermes/`, `feature/`, `chore/`, `fix/`
+- execute is blocked when the working tree is dirty
+
+Current limitations:
+
+- The harness is still advisory; it does not sandbox tools or prevent a caller from bypassing it.
+- The JSON schema validator is a lightweight subset validator, not a full JSON Schema engine.
+- Dirty-tree policy is intentionally conservative and may block harmless local source edits until committed/stashed.
+- Drift detection is still narrow and should be expanded with one tested rule at a time.
+
+Generated local artifacts are ignored by `.hermes/.gitignore`:
+
+- `.hermes/state/project-snapshot.json`
+- `.hermes/derived/harness-drift-report.json`
+- `.hermes/derived/harness-check-report.json`
+- `.hermes/derived/readiness-observe.json`
+- `.hermes/derived/readiness-execute.json`
+- `.hermes/derived/current-status.json` legacy/latest pointer

--- a/.hermes/agents/implementer.md
+++ b/.hermes/agents/implementer.md
@@ -1,0 +1,14 @@
+---
+project: goto
+role: implementer
+profile: goto
+---
+
+# goto / implementer
+
+Make the smallest correct code change for the selected task. Prefer reversible changes and preserve existing conventions.
+
+Project notes:
+- Workspace root: /Users/inchan/workspace
+- Current readiness score: 90
+- Preferred style: plan -> implement -> test -> verify -> review

--- a/.hermes/agents/planner.md
+++ b/.hermes/agents/planner.md
@@ -1,0 +1,14 @@
+---
+project: goto
+role: planner
+profile: goto
+---
+
+# goto / planner
+
+Turn the current state into a small prioritized next-step plan. Pick the highest-leverage goal and keep the scope small.
+
+Project notes:
+- Workspace root: /Users/inchan/workspace
+- Current readiness score: 90
+- Preferred style: plan -> implement -> test -> verify -> review

--- a/.hermes/agents/research.md
+++ b/.hermes/agents/research.md
@@ -1,0 +1,14 @@
+---
+project: goto
+role: research
+profile: goto
+---
+
+# goto / research
+
+Analyze the project state, constraints, and missing context. Prefer grounded evidence over guesses. Produce a short action-oriented summary.
+
+Project notes:
+- Workspace root: /Users/inchan/workspace
+- Current readiness score: 90
+- Preferred style: plan -> implement -> test -> verify -> review

--- a/.hermes/agents/reviewer.md
+++ b/.hermes/agents/reviewer.md
@@ -1,0 +1,14 @@
+---
+project: goto
+role: reviewer
+profile: goto
+---
+
+# goto / reviewer
+
+Review the result for correctness, scope creep, and maintainability. Call out risks and the next improvement.
+
+Project notes:
+- Workspace root: /Users/inchan/workspace
+- Current readiness score: 90
+- Preferred style: plan -> implement -> test -> verify -> review

--- a/.hermes/agents/verifier.md
+++ b/.hermes/agents/verifier.md
@@ -1,0 +1,14 @@
+---
+project: goto
+role: verifier
+profile: goto
+---
+
+# goto / verifier
+
+Run tests, dry-runs, or mechanical checks. Report exact pass/fail evidence and any gaps.
+
+Project notes:
+- Workspace root: /Users/inchan/workspace
+- Current readiness score: 90
+- Preferred style: plan -> implement -> test -> verify -> review

--- a/.hermes/cron-templates/observer.md
+++ b/.hermes/cron-templates/observer.md
@@ -1,0 +1,10 @@
+# Observer Cron Template
+
+Purpose: observe project state and write local artifacts only.
+
+Rules:
+- Use an absolute workdir.
+- Deliver local output only until explicitly promoted.
+- Do not create new cron jobs.
+- Do not modify product code.
+- If no new evidence exists, emit `[SILENT] no safe action`.

--- a/.hermes/cron-templates/operator.md
+++ b/.hermes/cron-templates/operator.md
@@ -1,0 +1,9 @@
+# Operator Cron Template
+
+Status: disabled until harness readiness passes and user explicitly approves activation.
+
+Rules:
+- Use an absolute workdir.
+- Do not create new cron jobs.
+- Execute at most one approved safe action per run.
+- Stop on main branch, critical drift, manual gate, approval-required action, or dirty unrelated tree.

--- a/.hermes/cron-templates/reviewer.md
+++ b/.hermes/cron-templates/reviewer.md
@@ -1,0 +1,9 @@
+# Reviewer Cron Template
+
+Purpose: summarize canonical harness artifacts and surface only useful changes.
+
+Rules:
+- Use an absolute workdir.
+- Do not create new cron jobs.
+- Do not execute product changes.
+- Report blocked/manual gates as valid outcomes.

--- a/.hermes/decisions/ADR-HERMES-001-harness-boundaries.md
+++ b/.hermes/decisions/ADR-HERMES-001-harness-boundaries.md
@@ -1,0 +1,52 @@
+# ADR-HERMES-001: Harness Boundaries
+
+Status: Accepted
+
+## Context
+
+The project needs a Hermes project-commander harness, but autonomous execution must not outrun observability or safety. The repo is a macOS developer utility where some verification requires OS state, user approval, credentials, or manual clean-machine QA.
+
+## Decision
+
+Hermes autonomy is gated by deterministic harness checks. The harness may observe, classify, plan, validate, and report before it may execute.
+
+### Allowed without extra approval
+
+- Read repository files.
+- Generate or update project-local `.hermes/` harness artifacts.
+- Run non-mutating harness validators.
+- Run repo-local tests and build/typecheck commands when they do not mutate user state.
+- Write run artifacts under `.hermes/runs/`, `.hermes/events/`, `.hermes/derived/`, and `.hermes/reports/`.
+
+### Blocked on `main`
+
+- Product code writes.
+- Release changes.
+- Package/install side effects.
+- Any action that creates a commit, tag, push, or release.
+
+### Approval required
+
+- Writes to `~/.goto`.
+- Writes to shell rc files.
+- Writes to `~/Applications` or `/Applications`.
+- `sudo`, `launchctl`, `pluginkit`, `pkill Finder`, app install/uninstall, package install.
+- Notarization, signing credentials, credential-store mutation.
+- Gateway/service installation or recurring cron activation.
+
+### Manual gates
+
+- Finder Sync enablement in macOS Settings.
+- Clean-machine package installation QA.
+- Launch-at-login user approval.
+- Signed/notarized release readiness.
+
+### Cron policy
+
+- Cron jobs must not create or modify cron jobs from inside cron runs.
+- Execution cron must default to local output.
+- Human-facing recurring reports require a separate activation checklist.
+
+## Consequences
+
+Safe stop is a successful outcome. A commander run may complete by reporting `blocked`, `manual_gate`, or `no_safe_action` with evidence instead of forcing churn.

--- a/.hermes/examples/decision.blocked-main-branch.json
+++ b/.hermes/examples/decision.blocked-main-branch.json
@@ -1,0 +1,18 @@
+{
+  "decision_id": "decision-block-main",
+  "run_id": "run-example-commander-dry-run",
+  "selected_action": "no_safe_action",
+  "alternatives_considered": [
+    "modify product code",
+    "create worktree",
+    "observe only"
+  ],
+  "classification": "blocked",
+  "why_now": "Main branch and unresolved harness drift make execution unsafe",
+  "why_not_more": "Autonomy should not outrun safety gates",
+  "stop_condition": "branch_main_blocks_execution",
+  "expected_verification": "check_harness_ready exits non-zero for execute mode",
+  "observation_refs": [
+    "obs-plan-tests-drift"
+  ]
+}

--- a/.hermes/examples/observation.repo-state.json
+++ b/.hermes/examples/observation.repo-state.json
@@ -1,0 +1,10 @@
+{
+  "observation_id": "obs-plan-tests-drift",
+  "source": "snapshot_project",
+  "observed_at": "2026-04-27T22:08:46Z",
+  "fact": ".hermes/plan.json says signals.tests=false while repo contains documented Node and Swift tests",
+  "evidence_path": ".hermes/plan.json",
+  "evidence_excerpt": "\"tests\": false",
+  "confidence": "high",
+  "staleness_risk": "medium"
+}

--- a/.hermes/examples/run.commander-dry-run.json
+++ b/.hermes/examples/run.commander-dry-run.json
@@ -1,0 +1,16 @@
+{
+  "run_id": "run-example-commander-dry-run",
+  "started_at": "2026-04-27T22:08:46Z",
+  "actor": "hermes",
+  "role": "commander",
+  "trigger_type": "dry_run",
+  "workdir": "/Users/inchan/workspace/goto",
+  "branch": "main",
+  "git_status_summary": "## main...origin/main; .hermes untracked",
+  "goal": "Evaluate harness readiness without product writes",
+  "mode": "observe",
+  "outcome": "blocked",
+  "artifact_paths": [
+    ".hermes/derived/harness-drift-report.json"
+  ]
+}

--- a/.hermes/examples/verification.manual-gate-needed.json
+++ b/.hermes/examples/verification.manual-gate-needed.json
@@ -1,0 +1,12 @@
+{
+  "verification_id": "verify-manual-gate-example",
+  "run_id": "run-example-commander-dry-run",
+  "commands_run": [],
+  "manual_checks": [
+    "Enable Finder Sync extension in macOS Settings",
+    "Confirm Finder toolbar launch manually"
+  ],
+  "result": "blocked",
+  "evidence_excerpt": "Manual Finder extension enablement is required",
+  "residual_risk": "Cannot be completed by autonomous repo-local scripts"
+}

--- a/.hermes/examples/verification.verify-sh-ci.json
+++ b/.hermes/examples/verification.verify-sh-ci.json
@@ -1,0 +1,11 @@
+{
+  "verification_id": "verify-ci-example",
+  "run_id": "run-example-commander-dry-run",
+  "commands_run": [
+    "scripts/verify.sh --ci"
+  ],
+  "manual_checks": [],
+  "result": "not_applicable",
+  "evidence_excerpt": "Example only; command not run for this harness bootstrap",
+  "residual_risk": "Product CI verification remains separate from harness validation"
+}

--- a/.hermes/operating-system.md
+++ b/.hermes/operating-system.md
@@ -1,0 +1,29 @@
+# Hermes Project Operating System
+
+## Purpose
+
+This file defines how a future goto project commander operates. It is a convenience surface, not canonical truth. Canonical records live in `.hermes/runs/`, `.hermes/events/`, `.hermes/state/`, and `.hermes/derived/`.
+
+## Run Sequence
+
+1. Snapshot project state with `.hermes/scripts/snapshot_project.py`.
+2. Validate schemas and examples with `.hermes/scripts/validate_harness.py`.
+3. Check readiness with `.hermes/scripts/check_harness_ready.py`.
+4. Observe repo state and record observations.
+5. Classify possible actions as read-only, safe write, verification, manual gate, approval-required, or blocked.
+6. Select the smallest safe action or stop with evidence.
+7. Execute only if readiness and action classification allow it.
+8. Verify mechanically where possible.
+9. Review artifact evidence and residual risk.
+10. Derive reports from canonical artifacts.
+
+## Stop Conditions
+
+- Main branch product write would be required.
+- User-state side effect would be required.
+- Manual macOS gate would be required.
+- Harness drift is critical.
+- No safe action exists.
+- Two management-only runs occur without new evidence.
+
+A safe stop is a valid successful outcome when it prevents fake progress.

--- a/.hermes/plan.json
+++ b/.hermes/plan.json
@@ -1,0 +1,21 @@
+{
+  "project": "goto",
+  "workspace_root": "/Users/inchan/workspace",
+  "score": 90,
+  "roles": [
+    "research",
+    "planner",
+    "implementer",
+    "verifier",
+    "reviewer"
+  ],
+  "signals": {
+    "guidance": 3,
+    "agent_cfg": 2,
+    "tests": true,
+    "docs": true,
+    "code_dirs": true,
+    "git": true
+  },
+  "last_reconciled_by": "snapshot_project detected live repo tests; repaired from false to true"
+}

--- a/.hermes/plans/2026-04-23_010620-finder-stage-debugging.md
+++ b/.hermes/plans/2026-04-23_010620-finder-stage-debugging.md
@@ -1,0 +1,126 @@
+# Finder Stage Debugging Plan
+
+> For Hermes: execute in strict order with a self-critique and one self-improvement loop after each stage.
+
+Goal: restore a reliable Finder path for goto by separating runtime/install-surface issues from source-level regressions, then fixing source-of-truth regressions with tests first.
+
+Architecture:
+- Treat Finder as a pipeline with explicit boundaries: install surface -> extension registration -> Finder invocation -> folder resolution -> launch dispatch -> terminal open.
+- Fix only source-of-truth regressions in repo code; treat stale local installs as environment state to be corrected manually after code-level safeguards exist.
+
+Tech Stack: Node test runner, Ruby Xcode project generator, Swift Finder Sync extension, macOS PlugInKit / pkgutil / PlistBuddy.
+
+---
+
+## Stage 1 — 탐색
+
+Objective: collect current, legacy, and runtime evidence for every Finder hop.
+
+Evidence checkpoints:
+- Running process path
+- ~/Applications vs /Applications bundle ids, versions, PlugIns contents
+- PlugInKit listing
+- pkg receipt version
+- current Finder extension code path
+- legacy bridge code path
+- build/install/package scripts
+
+Self-critique questions:
+- Did we distinguish current source from current machine state?
+- Did we identify start and end points explicitly?
+- Did we avoid assuming stale installs reflect current HEAD?
+
+Improvement loop:
+- If a boundary is still ambiguous, add one targeted command or file read and update the evidence map.
+
+## Stage 2 — 분석
+
+Objective: split findings into runtime blockers vs source regressions.
+
+Expected analysis outputs:
+1. First runtime failing stage on this Mac
+2. Current HEAD code-path differences vs legacy path
+3. Source regressions that can break future builds even if runtime state is corrected
+
+Self-critique questions:
+- Are we conflating symptom with root cause?
+- Is each claimed cause backed by direct file or command evidence?
+- Did we separate “stale install” from “repo bug”?
+
+Improvement loop:
+- Remove any claim not backed by a file/command and restate it as a hypothesis if needed.
+
+## Stage 3 — 설계
+
+Objective: design the smallest safe repo changes.
+
+Planned design scope:
+- Restore Finder Sync target entitlements wiring in the Xcode project generator
+- Add regression tests for generated project settings
+- Add/extend install-copy smoke test so local app copies preserve embedded PlugIns
+- Do not redesign Finder architecture yet unless evidence shows the direct-launch design itself is broken after install/runtime issues are fixed
+
+Self-critique questions:
+- Is the design minimal and evidence-driven?
+- Does it target source-of-truth files rather than generated artifacts?
+- Are we avoiding speculative architecture churn?
+
+Improvement loop:
+- Trim any change that is not directly tied to a proven failing stage.
+
+## Stage 4 — 계획
+
+Objective: convert the design into TDD-sized tasks.
+
+Task list:
+1. Add failing test: generated project includes Finder Sync CODE_SIGN_ENTITLEMENTS
+2. Add failing test: install-app copies embedded PlugIns/GotoFinderSync.appex when present
+3. Patch scripts/generate_macos_project.rb minimally
+4. Regenerate project and verify pbxproj contains entitlements setting
+5. Run targeted tests
+6. Run broader native script tests
+7. Review diffs and summarize remaining manual runtime action
+
+Self-critique questions:
+- Are tasks small and verifiable?
+- Is every code change preceded by a failing test?
+- Are manual environment steps separated from repo changes?
+
+Improvement loop:
+- Split any task that bundles multiple behavioral assertions.
+
+## Stage 5 — 구현
+
+Objective: implement only after RED tests exist.
+
+Rules:
+- No production edit before failing tests
+- Patch only source-of-truth files
+- Keep changes minimal
+
+## Stage 6 — 테스트
+
+Objective: run RED -> GREEN -> broader verification.
+
+Commands:
+- node --test product/cli/test/native-scripts.test.js
+- node --test product/cli/test/install-smoke.test.js
+- scripts/build-app.sh <tmpdir> as needed for manual verification
+
+## Stage 7 — 리뷰
+
+Objective: self-critique diff quality and behavioral coverage.
+
+Checks:
+- No unintended architecture changes
+- Tests specifically cover the proven regression
+- Generated project behavior matches design intent
+
+## Stage 8 — 퀄리티
+
+Objective: final quality gate and user-facing next-action summary.
+
+Outputs:
+- What repo bug was fixed
+- What runtime/manual cleanup still remains on this Mac
+- Exact manual verification steps for Finder after reinstall

--- a/.hermes/plans/2026-04-27_220846-hermes-harness-observability-workflows.md
+++ b/.hermes/plans/2026-04-27_220846-hermes-harness-observability-workflows.md
@@ -1,0 +1,679 @@
+# Hermes Harness Observability Workflow Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build the harness for operating future project-level Hermes commanders: observable, testable, bounded workflows before enabling autonomous execution.
+
+**Architecture:** Treat `.hermes/` as the project-local operating surface, but do not let prose become canonical truth. Create a deterministic foundation first: schemas, event logs, state snapshots, workflow contracts, validators, and small dry-run scripts. Let LLM agents propose and summarize; let code validate, gate, classify, and compute observability status.
+
+**Tech Stack:** Markdown/YAML/JSON artifacts under `.hermes/`; Node.js or Python scripts for validators and reports; existing repo verification commands (`node --test product/cli/test/*.test.js`, `scripts/verify.sh`, `scripts/test-native.sh`, `scripts/typecheck-native.sh`); Hermes profiles/cron only after dry-run evidence exists.
+
+---
+
+## Current Context / Evidence
+
+- Repo: `goto`, a local-first macOS developer utility with CLI, menu bar app, and Finder Sync extension.
+- Current branch from `git status`: `main...origin/main`.
+- Current `.hermes/` exists but is untracked.
+- Existing `.hermes/plan.json` says `signals.tests: false`, but README documents Node and Swift tests. This is already an observability defect: the harness can be confidently wrong.
+- Existing `.hermes/profile.md` has broad role prompts and readiness score 90, but lacks measurable operating contracts, event schemas, validation scripts, and stop conditions.
+- `docs/planning/ROADMAP.md` contains several manual/OS-gated phases: Finder Sync enablement, launch-at-login, package install, clean-machine QA, notarization. A commander must not convert those into fake automated progress.
+
+## Design Principle
+
+Before running autonomous Hermes as a project operator, build the operator's black box recorder.
+
+The first system should answer:
+
+1. What did Hermes observe?
+2. What did it decide?
+3. Why did it decide that?
+4. What did it change?
+5. How was it verified?
+6. What stopped it?
+7. Was the run useful or noisy?
+8. Did the harness itself drift from repo truth?
+
+If those questions are not machine-checkable, do not enable recurring autonomous execution.
+
+---
+
+## Layer Model
+
+### Layer 1 — Canonical Records
+
+Append-only or immutable-per-run artifacts.
+
+Proposed files:
+
+```text
+.hermes/state/project-snapshot.json
+.hermes/events/YYYY-MM-DD/<run-id>.jsonl
+.hermes/runs/<run-id>/run.json
+.hermes/runs/<run-id>/observations.json
+.hermes/runs/<run-id>/decision.json
+.hermes/runs/<run-id>/verification.json
+.hermes/runs/<run-id>/review.json
+.hermes/runs/<run-id>/artifacts.json
+.hermes/decisions/ADR-HERMES-001-harness-boundaries.md
+```
+
+Canonical records should be written by scripts or by tightly specified templates.
+
+### Layer 2 — Deterministic Derivations
+
+Computed from canonical records.
+
+Proposed files:
+
+```text
+.hermes/derived/current-status.json
+.hermes/derived/observability-scorecard.json
+.hermes/derived/workflow-health.json
+.hermes/derived/harness-drift-report.json
+.hermes/reports/latest.md
+```
+
+### Layer 3 — Convenience Surfaces
+
+Human-readable reports, summaries, commander prompts, role prompts.
+
+Proposed files:
+
+```text
+.hermes/operating-system.md
+.hermes/workflows/*.md
+.hermes/agents/*.md
+.hermes/reports/*.md
+```
+
+Rule: Layer 3 may summarize Layer 1/2, but must not be the source of truth.
+
+---
+
+## Roadmap
+
+## Roadmap 0: Freeze Safety Boundaries Before Building
+
+### Task 0.1: Write harness boundary ADR
+
+**Objective:** Define what autonomous Hermes may and may not do in this repo.
+
+**Files:**
+- Create: `.hermes/decisions/ADR-HERMES-001-harness-boundaries.md`
+
+**BDD Story:**
+- Given the repo is on `main`
+- When a commander run evaluates a possible code change
+- Then it must classify the action as blocked unless a safe branch/worktree exists
+
+**Required content:**
+- Main branch write policy: no code writes on `main`.
+- User-state side effect policy: no automatic writes to `~/.goto`, shell rc files, `~/Applications`, `/Applications`, `launchctl`, `pluginkit`, `pkill Finder`, `sudo`, notarization, or credential stores.
+- Manual gate policy: Finder Sync enablement, clean install, package install, notarization, launch-at-login user approval are manual/blocked unless explicitly authorized.
+- Cron policy: cron jobs must not create cron jobs.
+- Run scope policy: one run may complete one small task or produce one blocked diagnostic.
+
+**Acceptance criteria:**
+- ADR exists.
+- It explicitly lists allowed, blocked, and approval-required actions.
+- It defines safe stop as a successful outcome.
+
+### Task 0.2: Define action classification taxonomy
+
+**Objective:** Make every proposed action machine-classifiable before execution.
+
+**Files:**
+- Create: `.hermes/schemas/action-classification.schema.json`
+- Create: `.hermes/examples/action-classification.safe-doc.json`
+- Create: `.hermes/examples/action-classification.blocked-main.json`
+- Create: `.hermes/examples/action-classification.manual-gate.json`
+
+**BDD Story:**
+- Given a proposed action that touches `/Applications`
+- When validation runs
+- Then the action is classified as `approval_required` or `blocked`, not `safe_write`
+
+**Classification values:**
+- `read_only`
+- `safe_repo_write`
+- `safe_repo_verify`
+- `approval_required`
+- `manual_gate`
+- `blocked`
+
+**Acceptance criteria:**
+- Examples cover at least one safe action, one main-branch block, one manual OS gate.
+- Schema requires reason, evidence, affected_paths, and required_approval fields.
+
+---
+
+## Roadmap 1: Canonical Observability Records
+
+### Task 1.1: Define run record schema
+
+**Objective:** Every commander/subagent/cron run has a canonical envelope.
+
+**Files:**
+- Create: `.hermes/schemas/run.schema.json`
+- Create: `.hermes/examples/run.commander-dry-run.json`
+
+**Required fields:**
+- `run_id`
+- `started_at`
+- `actor`
+- `role`
+- `trigger_type` (`manual`, `cron`, `delegated`, `dry_run`)
+- `workdir`
+- `branch`
+- `git_status_summary`
+- `goal`
+- `mode` (`observe`, `plan`, `execute`, `verify`, `review`)
+- `outcome` (`completed`, `blocked`, `no_safe_action`, `failed`)
+- `artifact_paths`
+
+**Acceptance criteria:**
+- A dry-run example validates.
+- The schema can represent blocked/no-op runs without pretending failure.
+
+### Task 1.2: Define observation schema
+
+**Objective:** Separate what Hermes observed from what Hermes decided.
+
+**Files:**
+- Create: `.hermes/schemas/observation.schema.json`
+- Create: `.hermes/examples/observation.repo-state.json`
+
+**Required fields:**
+- `source`
+- `observed_at`
+- `fact`
+- `evidence_path`
+- `evidence_excerpt`
+- `confidence`
+- `staleness_risk`
+
+**Acceptance criteria:**
+- Observation examples include the known defect: `.hermes/plan.json` says tests false while README documents tests.
+
+### Task 1.3: Define decision schema
+
+**Objective:** Record why a run selected or rejected a task.
+
+**Files:**
+- Create: `.hermes/schemas/decision.schema.json`
+- Create: `.hermes/examples/decision.blocked-main-branch.json`
+
+**Required fields:**
+- `decision_id`
+- `run_id`
+- `selected_action`
+- `alternatives_considered`
+- `classification`
+- `why_now`
+- `why_not_more`
+- `stop_condition`
+- `expected_verification`
+
+**Acceptance criteria:**
+- A decision can select `no_safe_action` with a valid reason.
+- A decision must reference observations by id or artifact path.
+
+### Task 1.4: Define verification schema
+
+**Objective:** Prevent evidence-free completion claims.
+
+**Files:**
+- Create: `.hermes/schemas/verification.schema.json`
+- Create: `.hermes/examples/verification.verify-sh-ci.json`
+- Create: `.hermes/examples/verification.manual-gate-needed.json`
+
+**Required fields:**
+- `verification_id`
+- `run_id`
+- `commands_run`
+- `manual_checks`
+- `result` (`pass`, `fail`, `blocked`, `not_applicable`)
+- `evidence_excerpt`
+- `residual_risk`
+
+**Acceptance criteria:**
+- Manual gate can be represented as blocked, not pass.
+- Completion reports must reference verification artifact.
+
+---
+
+## Roadmap 2: Deterministic Validation Harness
+
+### Task 2.1: Add schema validator script
+
+**Objective:** Validate all `.hermes/schemas`, `.hermes/examples`, and latest run artifacts.
+
+**Files:**
+- Create: `.hermes/scripts/validate_harness.py`
+- Create: `.hermes/tests/test_validate_harness.py`
+
+**BDD Story:**
+- Given valid example artifacts
+- When `python3 .hermes/scripts/validate_harness.py` runs
+- Then it exits 0 and reports all examples valid
+
+**Subtasks:**
+1. Write failing test for valid examples.
+2. Implement minimal JSON loading and schema validation.
+3. Add clear error messages with file paths.
+4. Run test.
+5. Run validator directly.
+
+**Acceptance criteria:**
+- Invalid JSON reports exact path.
+- Missing required field reports exact schema and artifact.
+- No repo product code is touched.
+
+### Task 2.2: Add project snapshot generator
+
+**Objective:** Generate a machine-readable repo state snapshot before any run.
+
+**Files:**
+- Create: `.hermes/scripts/snapshot_project.py`
+- Create: `.hermes/tests/test_snapshot_project.py`
+- Output: `.hermes/state/project-snapshot.json`
+
+**Snapshot fields:**
+- branch
+- dirty/untracked status
+- known docs present
+- test paths present
+- verification commands present
+- product surfaces present
+- current `.hermes/plan.json` signals
+- detected inconsistencies
+
+**Acceptance criteria:**
+- It detects tests exist in this repo.
+- It flags existing `signals.tests: false` as drift.
+- It does not run product tests; it only observes structure.
+
+### Task 2.3: Add observability scorecard derivation
+
+**Objective:** Compute whether the harness is safe enough to operate.
+
+**Files:**
+- Create: `.hermes/scripts/derive_observability_scorecard.py`
+- Create: `.hermes/tests/test_observability_scorecard.py`
+- Output: `.hermes/derived/observability-scorecard.json`
+
+**Score categories:**
+- `snapshot_freshness`
+- `schema_validity`
+- `decision_traceability`
+- `verification_traceability`
+- `stop_condition_coverage`
+- `side_effect_guard_coverage`
+- `cron_safety`
+- `harness_drift`
+
+**Acceptance criteria:**
+- Scorecard can fail/warn/pass per category.
+- Existing plan drift produces warn/fail until repaired.
+
+### Task 2.4: Add aggregate harness check
+
+**Objective:** One command determines whether autonomous operation is allowed.
+
+**Files:**
+- Create: `.hermes/scripts/check_harness_ready.py`
+- Create: `.hermes/tests/test_check_harness_ready.py`
+
+**Command:**
+
+```bash
+python3 .hermes/scripts/check_harness_ready.py
+```
+
+**Exit behavior:**
+- Exit 0: observation/planning allowed and execution allowed.
+- Exit 10: observation/planning allowed, execution blocked.
+- Exit 20: harness invalid, no autonomous run allowed.
+
+**Acceptance criteria:**
+- On `main`, execution is blocked unless explicitly in observe/plan mode.
+- Drift in `.hermes/plan.json` blocks execution until updated or waived.
+
+---
+
+## Roadmap 3: Workflow Contracts
+
+### Task 3.1: Write operating system contract
+
+**Objective:** Define how commander runs proceed.
+
+**Files:**
+- Create or replace: `.hermes/operating-system.md`
+
+**Workflow:**
+1. Snapshot project.
+2. Validate harness.
+3. Observe repo state.
+4. Classify possible actions.
+5. Select smallest safe action or stop.
+6. Execute only if allowed.
+7. Verify.
+8. Review.
+9. Write run artifacts.
+10. Derive scorecard/report.
+
+**Acceptance criteria:**
+- The contract says no execution before harness validation.
+- It defines no-safe-action as valid.
+- It requires all final reports to include artifact paths.
+
+### Task 3.2: Define workflow documents
+
+**Objective:** Make each workflow independently understandable and testable.
+
+**Files:**
+- Create: `.hermes/workflows/observe.md`
+- Create: `.hermes/workflows/plan.md`
+- Create: `.hermes/workflows/execute.md`
+- Create: `.hermes/workflows/verify.md`
+- Create: `.hermes/workflows/review.md`
+- Create: `.hermes/workflows/cron-governance.md`
+
+**Acceptance criteria:**
+- Each workflow has inputs, outputs, allowed side effects, stop conditions, and required artifacts.
+- Execute workflow explicitly depends on successful observe + plan + readiness check.
+
+### Task 3.3: Refine role prompts into contracts
+
+**Objective:** Prevent role prompts from becoming shallow self-confirmation.
+
+**Files:**
+- Modify: `.hermes/agents/research.md`
+- Modify: `.hermes/agents/planner.md`
+- Modify: `.hermes/agents/implementer.md`
+- Modify: `.hermes/agents/verifier.md`
+- Modify: `.hermes/agents/reviewer.md`
+
+**Required role boundaries:**
+- Researcher: read-only, observations only.
+- Planner: no implementation, decisions and acceptance criteria only.
+- Implementer: only executes approved `safe_repo_write` tasks.
+- Verifier: write-forbidden, command evidence only.
+- Reviewer: diff/artifact review only, no new feature expansion.
+
+**Acceptance criteria:**
+- Every role prompt has forbidden actions.
+- Every role prompt has required output schema/path.
+
+---
+
+## Roadmap 4: Observability Reports
+
+### Task 4.1: Generate latest run report
+
+**Objective:** Human-readable report from canonical records.
+
+**Files:**
+- Create: `.hermes/scripts/generate_run_report.py`
+- Create: `.hermes/tests/test_generate_run_report.py`
+- Output: `.hermes/reports/latest.md`
+
+**Report sections:**
+- Run summary
+- Observed facts
+- Decision
+- Action classification
+- Verification evidence
+- Stop condition
+- Residual risk
+- Next eligible action
+
+**Acceptance criteria:**
+- Report generation does not invent facts absent from canonical records.
+- Missing verification appears as fail/warn, not omitted.
+
+### Task 4.2: Generate harness drift report
+
+**Objective:** Detect when `.hermes` metadata contradicts repo reality.
+
+**Files:**
+- Create: `.hermes/scripts/generate_harness_drift_report.py`
+- Create: `.hermes/tests/test_harness_drift_report.py`
+- Output: `.hermes/derived/harness-drift-report.json`
+
+**Initial expected drift:**
+- `.hermes/plan.json` says tests false while repo has documented test files/commands.
+
+**Acceptance criteria:**
+- Drift report identifies this defect.
+- It suggests exact artifact to repair, but does not silently overwrite it.
+
+### Task 4.3: Add noise/churn detector
+
+**Objective:** Detect when the harness is producing management work without product value.
+
+**Files:**
+- Create: `.hermes/scripts/detect_harness_noise.py`
+- Create: `.hermes/tests/test_detect_harness_noise.py`
+
+**Signals:**
+- multiple runs with no verification
+- repeated planning without execution
+- repeated docs-only changes without decision impact
+- cron reports with no new evidence
+- same blocked condition repeated without escalation
+
+**Acceptance criteria:**
+- Detector can emit `pass`, `warn`, `fail`.
+- Two consecutive management-only runs produce at least `warn`.
+
+---
+
+## Roadmap 5: Cron and Autonomy Gate, Dry-Run First
+
+### Task 5.1: Define cron prompt templates without scheduling them
+
+**Objective:** Prepare cron workflows without enabling them.
+
+**Files:**
+- Create: `.hermes/cron-templates/observer.md`
+- Create: `.hermes/cron-templates/reviewer.md`
+- Create: `.hermes/cron-templates/operator.md`
+
+**Rules:**
+- Observer: read-only, local output only.
+- Reviewer: summarize canonical artifacts, no code writes.
+- Operator: disabled until harness readiness pass and branch policy satisfied.
+
+**Acceptance criteria:**
+- Templates contain `do not create new cron jobs`.
+- Templates require `workdir`.
+- Templates require local delivery unless explicitly promoted.
+
+### Task 5.2: Add cron preflight checker
+
+**Objective:** Verify a cron job definition before creation.
+
+**Files:**
+- Create: `.hermes/scripts/check_cron_template.py`
+- Create: `.hermes/tests/test_check_cron_template.py`
+
+**Checks:**
+- has absolute workdir
+- has no recursive cron creation permission
+- has delivery target declared
+- has stop/no-safe-action behavior
+- has required artifact outputs
+
+**Acceptance criteria:**
+- Bad template fails with exact reason.
+- Good observer/reviewer templates pass.
+- Operator template warns/blocks until readiness gate passes.
+
+### Task 5.3: Manual activation checklist
+
+**Objective:** Explicitly require user approval before scheduling recurring work.
+
+**Files:**
+- Create: `.hermes/workflows/activation-checklist.md`
+
+**Checklist:**
+- Harness validation passes.
+- Drift report is clean or intentionally waived.
+- Branch policy satisfied.
+- First observer dry-run produced useful evidence.
+- First reviewer dry-run produced useful evidence.
+- Operator remains disabled unless user explicitly approves.
+
+**Acceptance criteria:**
+- No cron is created by this plan.
+- Activation is a separate later decision.
+
+---
+
+## Roadmap 6: Repair Existing `.hermes` Metadata After Validators Exist
+
+### Task 6.1: Recompute `.hermes/plan.json`
+
+**Objective:** Fix known false signal only after snapshot/drift tools can prove it.
+
+**Files:**
+- Modify: `.hermes/plan.json`
+- Modify: `.hermes/profile.md` if score/roles change
+- Modify: `.hermes/README.md` if readiness wording changes
+
+**Acceptance criteria:**
+- `signals.tests` reflects actual repo state.
+- Score explanation is reproducible by snapshot/scorecard tools.
+- The correction is referenced in drift report/run report.
+
+### Task 6.2: Add harness maintenance note to project docs only if useful
+
+**Objective:** Avoid polluting product README with agent internals unless necessary.
+
+**Files:**
+- Possibly create: `.hermes/README.md` expanded section
+- Avoid changing: `README.md` unless user wants public docs to mention Hermes harness
+
+**Acceptance criteria:**
+- Product docs stay product-focused.
+- Harness docs stay under `.hermes/`.
+
+---
+
+## Validation Commands
+
+Initial harness validation commands after implementation:
+
+```bash
+python3 .hermes/scripts/validate_harness.py
+python3 .hermes/scripts/snapshot_project.py
+python3 .hermes/scripts/derive_observability_scorecard.py
+python3 .hermes/scripts/check_harness_ready.py
+python3 .hermes/scripts/generate_harness_drift_report.py
+python3 .hermes/scripts/generate_run_report.py
+```
+
+Repo product verification remains separate:
+
+```bash
+node --test product/cli/test/*.test.js
+scripts/test-native.sh
+scripts/typecheck-native.sh
+scripts/verify.sh
+scripts/verify.sh --ci
+```
+
+Do not run OS/user-state side-effect commands automatically from the harness.
+
+---
+
+## Initial MVP Scope
+
+Build only these first:
+
+1. Boundary ADR.
+2. Run/observation/decision/verification schemas.
+3. Example artifacts.
+4. `snapshot_project.py`.
+5. `validate_harness.py`.
+6. `check_harness_ready.py`.
+7. `operating-system.md`.
+8. Drift report that catches the existing `signals.tests: false` defect.
+
+Do not yet create cron jobs.
+Do not yet run autonomous operator mode.
+Do not yet modify product code.
+Do not yet make profile aliases or gateway services.
+
+---
+
+## Risks and Mitigations
+
+### Risk: The harness becomes more important than the product
+
+Mitigation:
+- Noise detector.
+- Kill condition: two consecutive management-only runs without new evidence.
+- Reports must show product impact or blocked reason.
+
+### Risk: LLM summaries become canonical truth
+
+Mitigation:
+- Canonical JSON artifacts first.
+- Markdown reports are derived only.
+- Validators reject missing evidence.
+
+### Risk: Commander acts on stale or wrong `.hermes` metadata
+
+Mitigation:
+- Snapshot and drift report before every run.
+- Execution blocked on unresolved critical drift.
+
+### Risk: macOS/user-state side effects cause damage
+
+Mitigation:
+- Action classification schema.
+- Boundary ADR.
+- Approval-required list.
+- Main branch write block.
+
+### Risk: Too much ceremony for small tasks
+
+Mitigation:
+- Commander only for score >= 7 tasks.
+- Single-agent path remains default for small direct work.
+- No cron until dry-run evidence proves usefulness.
+
+---
+
+## Open Questions
+
+1. Should this harness be implemented in Python for simplicity, or Node.js to align with the CLI test stack?
+   - Recommendation: Python under `.hermes/scripts/` is acceptable because it is harness-local, but Node may be preferable if we want zero additional developer assumptions.
+
+2. Should `.hermes/` be committed to the repo?
+   - Recommendation: yes for generic harness contracts/schemas/workflows; no for private run logs if they may contain local paths or sensitive output. Add a `.hermes/.gitignore` to separate committed templates from local run artifacts.
+
+3. Should the commander profile be `goto` or a new `goto-commander` runtime profile?
+   - Recommendation: defer until dry-run harness passes. Runtime profile creation is an activation step, not foundation.
+
+4. Should cron be local-only or report to the user?
+   - Recommendation: local-only until reports prove signal value; one human-facing reviewer can be added later.
+
+---
+
+## Definition of Done for This Plan
+
+The harness foundation is ready when:
+
+- `.hermes` has explicit safety boundaries.
+- Every run can produce canonical run/observation/decision/verification artifacts.
+- Harness validators pass.
+- Snapshot detects repo facts and known drift.
+- Readiness checker can block unsafe execution.
+- Observability report shows evidence, not just prose.
+- No autonomous cron/operator has been enabled yet.
+
+Only after that should we consider creating project profiles, cron jobs, or autonomous commander loops.

--- a/.hermes/profile.md
+++ b/.hermes/profile.md
@@ -1,0 +1,32 @@
+---
+project: goto
+profile: goto
+workspace_root: /Users/inchan/workspace
+score: 90
+roles:
+  - research
+  - planner
+  - implementer
+  - verifier
+  - reviewer
+---
+
+# goto Hermes project profile
+
+Purpose:
+- Keep project-specific context local to this repository.
+- Choose the next useful improvement without needing a fresh design discussion every time.
+- Use role-based subagents for research, planning, implementation, verification, and review.
+
+Default operating rules:
+- Start with evidence from the repo, not assumptions.
+- Pick the smallest high-leverage goal first.
+- Prefer reversible changes and mechanical verification.
+- Record exclusions or failures instead of dropping them.
+
+Recommended roles:
+- research
+- planner
+- implementer
+- verifier
+- reviewer

--- a/.hermes/schemas/decision.schema.json
+++ b/.hermes/schemas/decision.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "title": "Hermes Decision",
+  "type": "object",
+  "required": [
+    "decision_id",
+    "run_id",
+    "selected_action",
+    "alternatives_considered",
+    "classification",
+    "why_now",
+    "why_not_more",
+    "stop_condition",
+    "expected_verification",
+    "observation_refs"
+  ],
+  "properties": {
+    "decision_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "selected_action": {
+      "type": "string"
+    },
+    "alternatives_considered": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "classification": {
+      "enum": [
+        "read_only",
+        "safe_repo_write",
+        "safe_repo_verify",
+        "approval_required",
+        "manual_gate",
+        "blocked"
+      ]
+    },
+    "why_now": {
+      "type": "string"
+    },
+    "why_not_more": {
+      "type": "string"
+    },
+    "stop_condition": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "expected_verification": {
+      "type": "string"
+    },
+    "observation_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/.hermes/schemas/observation.schema.json
+++ b/.hermes/schemas/observation.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "title": "Hermes Observation",
+  "type": "object",
+  "required": [
+    "observation_id",
+    "source",
+    "observed_at",
+    "fact",
+    "evidence_path",
+    "evidence_excerpt",
+    "confidence",
+    "staleness_risk"
+  ],
+  "properties": {
+    "observation_id": {
+      "type": "string"
+    },
+    "source": {
+      "type": "string"
+    },
+    "observed_at": {
+      "type": "string"
+    },
+    "fact": {
+      "type": "string"
+    },
+    "evidence_path": {
+      "type": "string"
+    },
+    "evidence_excerpt": {
+      "type": "string"
+    },
+    "confidence": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "staleness_risk": {
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    }
+  }
+}

--- a/.hermes/schemas/run.schema.json
+++ b/.hermes/schemas/run.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "title": "Hermes Run Record",
+  "type": "object",
+  "required": [
+    "run_id",
+    "started_at",
+    "actor",
+    "role",
+    "trigger_type",
+    "workdir",
+    "branch",
+    "git_status_summary",
+    "goal",
+    "mode",
+    "outcome",
+    "artifact_paths"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string"
+    },
+    "started_at": {
+      "type": "string"
+    },
+    "actor": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string"
+    },
+    "trigger_type": {
+      "enum": [
+        "manual",
+        "cron",
+        "delegated",
+        "dry_run"
+      ]
+    },
+    "workdir": {
+      "type": "string"
+    },
+    "branch": {
+      "type": "string"
+    },
+    "git_status_summary": {
+      "type": "string"
+    },
+    "goal": {
+      "type": "string"
+    },
+    "mode": {
+      "enum": [
+        "observe",
+        "plan",
+        "execute",
+        "verify",
+        "review"
+      ]
+    },
+    "outcome": {
+      "enum": [
+        "completed",
+        "blocked",
+        "no_safe_action",
+        "failed"
+      ]
+    },
+    "artifact_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/.hermes/schemas/verification.schema.json
+++ b/.hermes/schemas/verification.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "title": "Hermes Verification",
+  "type": "object",
+  "required": [
+    "verification_id",
+    "run_id",
+    "commands_run",
+    "manual_checks",
+    "result",
+    "evidence_excerpt",
+    "residual_risk"
+  ],
+  "properties": {
+    "verification_id": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "commands_run": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "manual_checks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "result": {
+      "enum": [
+        "pass",
+        "fail",
+        "blocked",
+        "not_applicable"
+      ]
+    },
+    "evidence_excerpt": {
+      "type": "string"
+    },
+    "residual_risk": {
+      "type": "string"
+    }
+  }
+}

--- a/.hermes/scripts/check_harness_ready.py
+++ b/.hermes/scripts/check_harness_ready.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+import sys
+
+try:
+    from scripts.snapshot_project import build_snapshot
+    from scripts.validate_harness import validate_harness
+except ModuleNotFoundError:
+    from snapshot_project import build_snapshot
+    from validate_harness import validate_harness
+
+
+@dataclass
+class ReadinessResult:
+    exit_code: int
+    mode: str
+    issues: list[dict]
+
+    @property
+    def allowed(self) -> bool:
+        return self.exit_code == 0
+
+
+ALLOWED_MODES = {"observe", "plan", "verify", "review", "execute"}
+ALLOWED_EXECUTE_BRANCH_PREFIXES = ("hermes/", "feature/", "chore/", "fix/")
+
+ACTION_RULES = [
+    ("user_or_system_side_effect", ["~/.goto", "shell rc", "~/applications", "/applications", "launchctl", "pluginkit", "pkill finder", "sudo", "finder sync", "install-app", "goto.app"]),
+    ("scheduler_side_effect", ["cronjob", "cron job", "scheduled job", "recurring cron", "every hour", "every day"]),
+    ("repo_write", ["modify product/", "edit product/", "write product/", "change product/", "patch product/", "implement feature", "fix bug", "write .hermes", "edit .hermes", "modify .hermes", "update .hermes", "patch .hermes", "project-local .hermes", "harness artifacts", "add harness"]),
+]
+READ_ONLY_ACTION_TERMS = ["read", "inspect", "review", "observe", "list", "search", "check", "summarize"]
+
+
+def _normalise_action(text: str) -> str:
+    return re.sub(r"\s+", " ", text.casefold()).strip()
+
+
+def _matched_terms(text: str, terms: list[str]) -> list[str]:
+    return [term for term in terms if term in text]
+
+
+def classify_action(description: str | None) -> dict:
+    raw = description or "observe harness status"
+    text = _normalise_action(raw)
+
+    for classification, terms in ACTION_RULES:
+        matches = _matched_terms(text, terms)
+        if matches:
+            manual_gate = classification in {"user_or_system_side_effect", "scheduler_side_effect"}
+            return {
+                "description": raw,
+                "classification": classification,
+                "matched_terms": matches,
+                "requires_manual_gate": manual_gate,
+                "allowed_in_observe": False,
+                "allowed_in_execute": not manual_gate,
+                "reason": "matched deterministic action gate rule",
+            }
+
+    read_matches = _matched_terms(text, READ_ONLY_ACTION_TERMS)
+    if read_matches:
+        return {
+            "description": raw,
+            "classification": "read_only",
+            "matched_terms": read_matches,
+            "requires_manual_gate": False,
+            "allowed_in_observe": True,
+            "allowed_in_execute": True,
+            "reason": "read-only action terms detected",
+        }
+
+    return {
+        "description": raw,
+        "classification": "unknown_action",
+        "matched_terms": [],
+        "requires_manual_gate": True,
+        "allowed_in_observe": False,
+        "allowed_in_execute": False,
+        "reason": "no deterministic action gate rule matched; fail closed",
+    }
+
+
+def readiness_status_path(repo: Path | str, mode: str) -> Path:
+    repo = Path(repo).resolve()
+    safe_mode = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in mode)
+    return repo / ".hermes" / "derived" / f"readiness-{safe_mode}.json"
+
+
+def evaluate_readiness(repo: Path | str = Path("."), mode: str = "execute") -> ReadinessResult:
+    repo = Path(repo).resolve()
+    issues: list[dict] = []
+
+    if mode not in ALLOWED_MODES:
+        return ReadinessResult(
+            exit_code=20,
+            mode=mode,
+            issues=[{
+                "code": "unknown_readiness_mode",
+                "severity": "critical",
+                "message": f"Unknown readiness mode {mode!r}; allowed modes are {sorted(ALLOWED_MODES)}",
+            }],
+        )
+
+    validation = validate_harness(repo / ".hermes")
+    snapshot = build_snapshot(repo)
+
+    if validation.errors:
+        issues.append({
+            "code": "harness_invalid",
+            "severity": "critical",
+            "message": "; ".join(validation.errors[:3]),
+        })
+
+    critical_drift = [item for item in snapshot.get("detected_inconsistencies", []) if item.get("severity") == "critical"]
+    if critical_drift:
+        issues.append({
+            "code": "critical_harness_drift",
+            "severity": "critical",
+            "message": f"{len(critical_drift)} critical drift item(s) detected",
+        })
+
+    if mode == "execute":
+        git_health = snapshot.get("git_health", {})
+        branch = snapshot.get("branch")
+        if not git_health.get("is_git_repo") or not git_health.get("branch_known"):
+            issues.append({
+                "code": "git_context_unknown_blocks_execution",
+                "severity": "blocker",
+                "message": "Execution mode requires a known git repository and branch",
+            })
+        elif branch == "main":
+            issues.append({
+                "code": "branch_main_blocks_execution",
+                "severity": "blocker",
+                "message": "Execution mode is blocked on main branch",
+            })
+        elif not str(branch).startswith(ALLOWED_EXECUTE_BRANCH_PREFIXES):
+            issues.append({
+                "code": "branch_not_allowlisted_blocks_execution",
+                "severity": "blocker",
+                "message": f"Execution mode requires branch prefix {ALLOWED_EXECUTE_BRANCH_PREFIXES}; got {branch!r}",
+            })
+        if snapshot.get("dirty_worktree"):
+            issues.append({
+                "code": "dirty_worktree_blocks_execution",
+                "severity": "blocker",
+                "message": "Execution mode requires a clean working tree before autonomous changes",
+            })
+
+    if any(item.get("code") == "harness_invalid" for item in issues):
+        exit_code = 20
+    elif mode == "execute" and issues:
+        exit_code = 10
+    elif mode in {"observe", "plan", "verify", "review"} and any(item.get("severity") == "critical" for item in issues):
+        exit_code = 10
+    else:
+        exit_code = 0
+
+    return ReadinessResult(exit_code=exit_code, mode=mode, issues=issues)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    mode = "execute"
+    repo = Path(".")
+    if argv:
+        mode = argv[0]
+    if len(argv) > 1:
+        repo = Path(argv[1])
+    result = evaluate_readiness(repo, mode=mode)
+    out = readiness_status_path(repo, result.mode)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    status_payload = {"mode": result.mode, "exit_code": result.exit_code, "issues": result.issues}
+    out.write_text(json.dumps(status_payload, indent=2) + "\n")
+    legacy_out = repo / ".hermes" / "derived" / "current-status.json"
+    legacy_out.write_text(json.dumps(status_payload, indent=2) + "\n")
+    if result.exit_code == 0:
+        print(f"PASS mode={result.mode}")
+    else:
+        print(f"BLOCKED mode={result.mode} exit_code={result.exit_code}")
+        for issue in result.issues:
+            print(f"{issue['severity']} {issue['code']}: {issue['message']}")
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.hermes/scripts/generate_harness_drift_report.py
+++ b/.hermes/scripts/generate_harness_drift_report.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+from datetime import datetime, timezone
+
+try:
+    from scripts.snapshot_project import build_snapshot
+except ModuleNotFoundError:
+    from snapshot_project import build_snapshot
+
+
+def generate_drift_report(repo: Path | str = Path(".")) -> dict:
+    repo = Path(repo).resolve()
+    snapshot = build_snapshot(repo)
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo": str(repo),
+        "drift": snapshot.get("detected_inconsistencies", []),
+        "summary": {
+            "count": len(snapshot.get("detected_inconsistencies", [])),
+            "critical": sum(1 for item in snapshot.get("detected_inconsistencies", []) if item.get("severity") == "critical"),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    repo = Path(argv[0]) if argv else Path(".")
+    report = generate_drift_report(repo)
+    out = repo / ".hermes" / "derived" / "harness-drift-report.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2) + "\n")
+    print(str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.hermes/scripts/run_harness_checks.py
+++ b/.hermes/scripts/run_harness_checks.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+from datetime import datetime, timezone
+
+try:
+    from scripts.check_harness_ready import classify_action, evaluate_readiness
+    from scripts.generate_harness_drift_report import generate_drift_report
+    from scripts.snapshot_project import build_snapshot
+    from scripts.validate_harness import validate_harness
+except ModuleNotFoundError:
+    from check_harness_ready import classify_action, evaluate_readiness
+    from generate_harness_drift_report import generate_drift_report
+    from snapshot_project import build_snapshot
+    from validate_harness import validate_harness
+
+
+def _status_from_exit(exit_code: int) -> str:
+    if exit_code == 0:
+        return "pass"
+    if exit_code == 10:
+        return "blocked"
+    return "fail"
+
+
+def _operating_state(observe_status: str, execute_status: str) -> str:
+    if observe_status == "pass" and execute_status == "pass":
+        return "execute_ready"
+    if observe_status == "pass" and execute_status == "blocked":
+        return "stable_observe_only"
+    if observe_status == "blocked":
+        return "observe_blocked"
+    return "harness_unstable"
+
+
+def _safe_next_action(execute_status: str, preflight: dict) -> str:
+    if execute_status != "pass":
+        return "observe_or_review_only"
+    if preflight.get("requires_manual_gate") or not preflight.get("allowed_in_execute"):
+        return "manual_gate_required"
+    return "execute_allowed_by_harness"
+
+
+def run_harness_checks(repo: Path | str = Path("."), action_description: str | None = None) -> dict:
+    repo = Path(repo).resolve()
+    validation = validate_harness(repo / ".hermes")
+    snapshot = build_snapshot(repo)
+    drift = generate_drift_report(repo)
+    observe = evaluate_readiness(repo, mode="observe")
+    execute = evaluate_readiness(repo, mode="execute")
+    preflight = classify_action(action_description or "observe harness status")
+
+    validate_status = "pass" if validation.ok else "fail"
+    drift_status = "pass" if drift.get("summary", {}).get("critical", 0) == 0 else "fail"
+    observe_status = _status_from_exit(observe.exit_code)
+    execute_status = _status_from_exit(execute.exit_code)
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo": str(repo),
+        "steps": {
+            "validate_harness": {
+                "status": validate_status,
+                "validated_examples": validation.validated_examples,
+                "errors": validation.errors,
+            },
+            "snapshot_project": {
+                "status": "pass",
+                "branch": snapshot.get("branch"),
+                "signals": snapshot.get("signals", {}),
+                "product_surfaces": snapshot.get("product_surfaces", {}),
+            },
+            "drift_report": {
+                "status": drift_status,
+                "summary": drift.get("summary", {}),
+                "drift": drift.get("drift", []),
+            },
+        },
+        "readiness": {
+            "observe": {
+                "status": observe_status,
+                "exit_code": observe.exit_code,
+                "issues": observe.issues,
+            },
+            "execute": {
+                "status": execute_status,
+                "exit_code": execute.exit_code,
+                "issues": execute.issues,
+            },
+        },
+        "preflight": preflight,
+        "summary": {
+            "operating_state": _operating_state(observe_status, execute_status),
+            "safe_next_action": _safe_next_action(execute_status, preflight),
+        },
+    }
+
+
+def aggregate_exit_code(report: dict, require: str = "observe") -> int:
+    if require not in {"observe", "execute"}:
+        return 20
+    if report["steps"]["validate_harness"]["status"] == "fail":
+        return 20
+    if report["steps"]["drift_report"]["status"] == "fail":
+        return 10
+    observe = report["readiness"]["observe"]
+    execute = report["readiness"]["execute"]
+    if observe["status"] != "pass":
+        return observe["exit_code"] or 10
+    if require == "execute" and execute["status"] != "pass":
+        return execute["exit_code"] or 10
+    if require == "execute":
+        preflight = report.get("preflight", {})
+        if preflight.get("requires_manual_gate") or not preflight.get("allowed_in_execute"):
+            return 10
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    require = "observe"
+    action_description = None
+    paths = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--require-observe":
+            require = "observe"
+        elif arg == "--require-execute":
+            require = "execute"
+        elif arg == "--action":
+            if index + 1 >= len(argv):
+                print("ERROR --action requires a description", file=sys.stderr)
+                return 20
+            action_description = argv[index + 1]
+            index += 1
+        else:
+            paths.append(arg)
+        index += 1
+    repo = Path(paths[0]) if paths else Path(".")
+    report = run_harness_checks(repo, action_description=action_description)
+    out = repo / ".hermes" / "derived" / "harness-check-report.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2) + "\n")
+    print(str(out))
+    print(f"operating_state={report['summary']['operating_state']}")
+    observe = report["readiness"]["observe"]
+    execute = report["readiness"]["execute"]
+    print(f"observe={observe['status']} exit_code={observe['exit_code']}")
+    print(f"execute={execute['status']} exit_code={execute['exit_code']}")
+    print(f"require={require}")
+    return aggregate_exit_code(report, require=require)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.hermes/scripts/snapshot_project.py
+++ b/.hermes/scripts/snapshot_project.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+
+def _run(repo: Path, args: list[str]) -> str:
+    try:
+        return subprocess.check_output(args, cwd=repo, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return ""
+
+
+def _run_status(repo: Path, args: list[str]) -> tuple[int, str]:
+    try:
+        completed = subprocess.run(args, cwd=repo, text=True, capture_output=True, check=False)
+        return completed.returncode, completed.stdout.strip()
+    except Exception:
+        return 127, ""
+
+
+def _exists_any(repo: Path, paths: list[str]) -> bool:
+    return any((repo / path).exists() for path in paths)
+
+
+def _glob_any(repo: Path, patterns: list[str]) -> bool:
+    return any(any(repo.glob(pattern)) for pattern in patterns)
+
+
+def detect_tests(repo: Path) -> bool:
+    if _glob_any(repo, ["product/cli/test/*.test.js", "product/core/Tests/**/*.swift", "tests/**/*", "test/**/*"]):
+        return True
+    readme = repo / "README.md"
+    if readme.exists() and any(token in readme.read_text(errors="ignore") for token in ["node --test", "scripts/test-native.sh", "swift test"]):
+        return True
+    return False
+
+
+def _load_plan(repo: Path):
+    path = repo / ".hermes" / "plan.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {"_invalid": True}
+
+
+def build_snapshot(repo: Path | str = Path(".")) -> dict:
+    repo = Path(repo).resolve()
+    branch_code, branch = _run_status(repo, ["git", "branch", "--show-current"])
+    status_code, status = _run_status(repo, ["git", "status", "--short", "--branch"])
+    porcelain_code, porcelain = _run_status(repo, ["git", "status", "--porcelain"])
+    branch = branch or "unknown"
+    git_dir = repo / ".git"
+    git_health = {
+        "is_git_repo": git_dir.exists() and status_code == 0,
+        "branch_known": branch_code == 0 and branch != "unknown",
+        "status_known": status_code == 0,
+        "porcelain_known": porcelain_code == 0,
+    }
+    dirty_paths = [line[3:] if len(line) > 3 else line for line in porcelain.splitlines() if line.strip()]
+    tests = detect_tests(repo)
+    plan = _load_plan(repo)
+    inconsistencies: list[dict] = []
+    if isinstance(plan, dict):
+        plan_tests = plan.get("signals", {}).get("tests")
+        if plan_tests is False and tests:
+            inconsistencies.append({
+                "code": "plan_tests_signal_false_but_tests_detected",
+                "severity": "critical",
+                "artifact": ".hermes/plan.json",
+                "message": ".hermes/plan.json reports signals.tests=false, but repo tests are detected",
+            })
+        if plan.get("_invalid"):
+            inconsistencies.append({
+                "code": "plan_json_invalid",
+                "severity": "critical",
+                "artifact": ".hermes/plan.json",
+                "message": ".hermes/plan.json is not valid JSON",
+            })
+
+    snapshot = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "repo": str(repo),
+        "branch": branch,
+        "git_status_summary": status,
+        "git_health": git_health,
+        "dirty_worktree": bool(dirty_paths),
+        "dirty_paths": dirty_paths,
+        "signals": {
+            "guidance": _exists_any(repo, ["AGENTS.md", "CLAUDE.md", ".cursorrules"]),
+            "agent_cfg": (repo / ".hermes").exists(),
+            "tests": tests,
+            "docs": _exists_any(repo, ["README.md", "docs"]),
+            "code_dirs": _exists_any(repo, ["src", "app", "lib", "product"]),
+            "git": (repo / ".git").exists(),
+        },
+        "product_surfaces": {
+            "cli": (repo / "product" / "cli").exists(),
+            "macos_app": (repo / "product" / "macos" / "Goto").exists(),
+            "finder_sync": (repo / "product" / "macos" / "GotoFinderSync").exists(),
+        },
+        "verification_commands": [
+            command for command in [
+                "node --test product/cli/test/*.test.js" if (repo / "product" / "cli" / "test").exists() else None,
+                "scripts/test-native.sh" if (repo / "scripts" / "test-native.sh").exists() else None,
+                "scripts/typecheck-native.sh" if (repo / "scripts" / "typecheck-native.sh").exists() else None,
+                "scripts/verify.sh" if (repo / "scripts" / "verify.sh").exists() else None,
+            ] if command
+        ],
+        "plan_signals": plan.get("signals", {}) if isinstance(plan, dict) else {},
+        "detected_inconsistencies": inconsistencies,
+    }
+    return snapshot
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    repo = Path(argv[0]) if argv else Path(".")
+    snapshot = build_snapshot(repo)
+    out = repo / ".hermes" / "state" / "project-snapshot.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(snapshot, indent=2) + "\n")
+    print(str(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.hermes/scripts/validate_harness.py
+++ b/.hermes/scripts/validate_harness.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+import sys
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str] = field(default_factory=list)
+    validated_examples: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+SCHEMA_BY_PREFIX = {
+    "run": "run.schema.json",
+    "observation": "observation.schema.json",
+    "decision": "decision.schema.json",
+    "verification": "verification.schema.json",
+}
+
+
+def _load_json(path: Path, result: ValidationResult):
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # noqa: BLE001 - CLI validator should report exact path
+        result.errors.append(f"{path}: invalid JSON: {exc}")
+        return None
+
+
+def _schema_for_example(example_path: Path, schemas_dir: Path, result: ValidationResult):
+    name = example_path.name
+    for prefix, schema_name in SCHEMA_BY_PREFIX.items():
+        if name.startswith(prefix + "."):
+            schema = _load_json(schemas_dir / schema_name, result)
+            return schema
+    result.errors.append(f"{example_path}: no matching schema prefix")
+    return None
+
+
+def _validate_type(value, expected):
+    if isinstance(expected, list):
+        return any(_validate_type(value, item) for item in expected)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "null":
+        return value is None
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return True
+
+
+def _validate_against_schema(data: dict, schema: dict, path: Path) -> list[str]:
+    errors: list[str] = []
+    if schema.get("type") == "object" and not isinstance(data, dict):
+        return [f"{path}: expected object"]
+
+    required = schema.get("required", [])
+    for key in required:
+        if key not in data:
+            errors.append(f"{path}: missing required field {key}")
+
+    properties = schema.get("properties", {})
+    for key, value in data.items():
+        if schema.get("additionalProperties") is False and key not in properties:
+            errors.append(f"{path}: unexpected field {key}")
+            continue
+        prop = properties.get(key, {})
+        if "type" in prop and not _validate_type(value, prop["type"]):
+            errors.append(f"{path}: field {key} has wrong type")
+        if "enum" in prop and value not in prop["enum"]:
+            errors.append(f"{path}: field {key} value {value!r} not in enum")
+        if prop.get("type") == "array" and isinstance(value, list):
+            item_type = prop.get("items", {}).get("type")
+            if item_type:
+                for index, item in enumerate(value):
+                    if not _validate_type(item, item_type):
+                        errors.append(f"{path}: field {key}[{index}] has wrong type")
+    return errors
+
+
+def validate_harness(hermes_dir: Path | str = Path(".hermes")) -> ValidationResult:
+    hermes_dir = Path(hermes_dir)
+    result = ValidationResult()
+    schemas_dir = hermes_dir / "schemas"
+    examples_dir = hermes_dir / "examples"
+
+    required_schemas = sorted(SCHEMA_BY_PREFIX.values())
+    for schema_name in required_schemas:
+        schema_path = schemas_dir / schema_name
+        schema = _load_json(schema_path, result)
+        if schema is None:
+            continue
+        for key in ("title", "type", "required", "properties"):
+            if key not in schema:
+                result.errors.append(f"{schema_path}: missing schema key {key}")
+
+    for example_path in sorted(examples_dir.glob("*.json")):
+        data = _load_json(example_path, result)
+        schema = _schema_for_example(example_path, schemas_dir, result)
+        if data is None or schema is None:
+            continue
+        result.errors.extend(_validate_against_schema(data, schema, example_path))
+        result.validated_examples += 1
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    hermes_dir = Path(argv[0]) if argv else Path(".hermes")
+    result = validate_harness(hermes_dir)
+    if result.ok:
+        print(f"PASS validated_examples={result.validated_examples}")
+        return 0
+    for error in result.errors:
+        print(f"ERROR {error}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.hermes/tests/test_harness.py
+++ b/.hermes/tests/test_harness.py
@@ -1,0 +1,225 @@
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class HarnessTests(unittest.TestCase):
+    def setUp(self):
+        self.repo = Path(__file__).resolve().parents[2]
+
+    def _temp_repo_with_bad_plan(self):
+        temp = tempfile.TemporaryDirectory()
+        repo = Path(temp.name)
+        (repo / ".hermes").mkdir()
+        (repo / ".hermes" / "plan.json").write_text(json.dumps({"signals": {"tests": False}}))
+        (repo / "README.md").write_text("Run tests with `node --test product/cli/test/*.test.js`.\n")
+        return temp, repo
+
+    def _temp_repo_with_valid_harness(self, git: bool = False, branch: str | None = None):
+        temp = tempfile.TemporaryDirectory()
+        repo = Path(temp.name)
+        shutil.copytree(
+            self.repo / ".hermes",
+            repo / ".hermes",
+            ignore=shutil.ignore_patterns("derived", "state", "__pycache__", "*.pyc"),
+        )
+        (repo / "README.md").write_text("Temporary harness fixture.\n")
+        if git:
+            subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["git", "config", "user.email", "harness@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Harness Test"], cwd=repo, check=True)
+            if branch:
+                subprocess.run(["git", "checkout", "-b", branch], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["git", "add", "."], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["git", "commit", "-m", "seed harness fixture"], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return temp, repo
+
+    def test_validate_harness_accepts_committed_schema_examples(self):
+        from scripts.validate_harness import validate_harness
+
+        result = validate_harness(self.repo / ".hermes")
+
+        self.assertEqual([], result.errors)
+        self.assertGreaterEqual(result.validated_examples, 4)
+
+    def test_snapshot_detects_tests_in_live_repo(self):
+        from scripts.snapshot_project import build_snapshot
+
+        snapshot = build_snapshot(self.repo)
+
+        self.assertTrue(snapshot["signals"]["tests"])
+
+    def test_snapshot_detects_plan_drift_in_fixture(self):
+        from scripts.snapshot_project import build_snapshot
+
+        temp, repo = self._temp_repo_with_bad_plan()
+        with temp:
+            snapshot = build_snapshot(repo)
+
+        drift_codes = {item["code"] for item in snapshot["detected_inconsistencies"]}
+        self.assertIn("plan_tests_signal_false_but_tests_detected", drift_codes)
+
+    def test_harness_ready_blocks_execution_on_main_branch(self):
+        from scripts.check_harness_ready import evaluate_readiness
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="main")
+        with temp:
+            result = evaluate_readiness(repo, mode="execute")
+
+        self.assertIn(result.exit_code, {10, 20})
+        codes = {item["code"] for item in result.issues}
+        self.assertIn("branch_main_blocks_execution", codes)
+
+    def test_harness_ready_allows_observe_when_harness_valid(self):
+        from scripts.check_harness_ready import evaluate_readiness
+
+        result = evaluate_readiness(self.repo, mode="observe")
+
+        self.assertEqual(0, result.exit_code)
+        self.assertNotIn("harness_invalid", {item["code"] for item in result.issues})
+
+    def test_drift_report_names_plan_json_tests_signal_in_fixture(self):
+        from scripts.generate_harness_drift_report import generate_drift_report
+
+        temp, repo = self._temp_repo_with_bad_plan()
+        with temp:
+            report = generate_drift_report(repo)
+
+        codes = {item["code"] for item in report["drift"]}
+        self.assertIn("plan_tests_signal_false_but_tests_detected", codes)
+        self.assertTrue(any(".hermes/plan.json" in item["artifact"] for item in report["drift"]))
+
+    def test_readiness_status_paths_are_mode_specific(self):
+        from scripts.check_harness_ready import readiness_status_path
+
+        self.assertEqual(
+            self.repo / ".hermes" / "derived" / "readiness-observe.json",
+            readiness_status_path(self.repo, "observe"),
+        )
+        self.assertEqual(
+            self.repo / ".hermes" / "derived" / "readiness-execute.json",
+            readiness_status_path(self.repo, "execute"),
+        )
+
+    def test_aggregate_checks_report_observe_pass_and_execute_blocked_on_main(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="main")
+        with temp:
+            report = run_harness_checks(repo)
+
+        self.assertEqual("pass", report["steps"]["validate_harness"]["status"])
+        self.assertEqual("pass", report["steps"]["drift_report"]["status"])
+        self.assertEqual("pass", report["readiness"]["observe"]["status"])
+        self.assertEqual("blocked", report["readiness"]["execute"]["status"])
+        self.assertIn(
+            "branch_main_blocks_execution",
+            {issue["code"] for issue in report["readiness"]["execute"]["issues"]},
+        )
+        self.assertEqual("stable_observe_only", report["summary"]["operating_state"])
+        self.assertEqual(0, aggregate_exit_code(report, require="observe"))
+        self.assertEqual(10, aggregate_exit_code(report, require="execute"))
+
+    def test_unknown_readiness_mode_is_blocked(self):
+        from scripts.check_harness_ready import evaluate_readiness
+
+        result = evaluate_readiness(self.repo, mode="exectue")
+
+        self.assertEqual(20, result.exit_code)
+        self.assertIn("unknown_readiness_mode", {issue["code"] for issue in result.issues})
+
+    def test_execute_blocks_when_git_context_is_unknown(self):
+        from scripts.check_harness_ready import evaluate_readiness
+
+        temp, repo = self._temp_repo_with_valid_harness(git=False)
+        with temp:
+            result = evaluate_readiness(repo, mode="execute")
+
+        self.assertEqual(10, result.exit_code)
+        self.assertIn("git_context_unknown_blocks_execution", {issue["code"] for issue in result.issues})
+
+    def test_execute_blocks_dirty_worktree_on_allowed_branch(self):
+        from scripts.check_harness_ready import evaluate_readiness
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="hermes/test")
+        with temp:
+            (repo / "product-change.txt").write_text("untracked product change\n")
+            result = evaluate_readiness(repo, mode="execute")
+
+        self.assertEqual(10, result.exit_code)
+        self.assertIn("dirty_worktree_blocks_execution", {issue["code"] for issue in result.issues})
+
+    def test_preflight_classifies_read_only_as_allowed(self):
+        from scripts.check_harness_ready import classify_action
+
+        result = classify_action("read README.md and inspect product/cli/src/index.js")
+
+        self.assertEqual("read_only", result["classification"])
+        self.assertTrue(result["allowed_in_observe"])
+        self.assertFalse(result["requires_manual_gate"])
+
+    def test_preflight_classifies_project_local_harness_updates_as_repo_write(self):
+        from scripts.check_harness_ready import classify_action
+
+        result = classify_action("update project-local .hermes harness artifacts")
+
+        self.assertEqual("repo_write", result["classification"])
+        self.assertFalse(result["allowed_in_observe"])
+        self.assertTrue(result["allowed_in_execute"])
+        self.assertFalse(result["requires_manual_gate"])
+        self.assertIn("project-local .hermes", result["matched_terms"])
+
+    def test_preflight_blocks_user_or_system_side_effects(self):
+        from scripts.check_harness_ready import classify_action
+
+        result = classify_action("run pluginkit and pkill Finder after installing Goto.app to /Applications")
+
+        self.assertEqual("user_or_system_side_effect", result["classification"])
+        self.assertFalse(result["allowed_in_execute"])
+        self.assertTrue(result["requires_manual_gate"])
+        self.assertIn("pluginkit", result["matched_terms"])
+
+    def test_preflight_classifies_cron_creation_as_side_effect(self):
+        from scripts.check_harness_ready import classify_action
+
+        result = classify_action("create a recurring cron job to run observer every hour")
+
+        self.assertEqual("scheduler_side_effect", result["classification"])
+        self.assertFalse(result["allowed_in_execute"])
+        self.assertTrue(result["requires_manual_gate"])
+
+    def test_aggregate_report_includes_default_preflight_policy(self):
+        from scripts.run_harness_checks import run_harness_checks
+
+        report = run_harness_checks(self.repo)
+
+        self.assertEqual("read_only", report["preflight"]["classification"])
+        self.assertTrue(report["preflight"]["allowed_in_observe"])
+
+    def test_aggregate_report_classifies_requested_action(self):
+        from scripts.run_harness_checks import run_harness_checks
+
+        report = run_harness_checks(self.repo, action_description="create cron job for observer")
+
+        self.assertEqual("scheduler_side_effect", report["preflight"]["classification"])
+        self.assertTrue(report["preflight"]["requires_manual_gate"])
+
+    def test_execute_requirement_blocks_manual_gate_action_even_on_clean_allowed_branch(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="hermes/test")
+        with temp:
+            report = run_harness_checks(repo, action_description="install Goto.app to /Applications")
+
+        self.assertEqual("pass", report["readiness"]["execute"]["status"])
+        self.assertEqual("user_or_system_side_effect", report["preflight"]["classification"])
+        self.assertTrue(report["preflight"]["requires_manual_gate"])
+        self.assertEqual("manual_gate_required", report["summary"]["safe_next_action"])
+        self.assertEqual(10, aggregate_exit_code(report, require="execute"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.hermes/workflows/activation-checklist.md
+++ b/.hermes/workflows/activation-checklist.md
@@ -1,0 +1,13 @@
+# Hermes Harness Activation Checklist
+
+Do not schedule recurring autonomous work until all items pass.
+
+- [ ] Harness validation passes.
+- [ ] Snapshot is fresh.
+- [ ] Drift report is clean or intentionally waived.
+- [ ] Branch policy is satisfied.
+- [ ] Observer dry-run produced useful evidence.
+- [ ] Reviewer dry-run produced useful evidence.
+- [ ] Operator remains disabled unless explicitly approved.
+- [ ] Delivery target is local unless explicitly promoted.
+- [ ] Cron prompt says: do not create new cron jobs.

--- a/.hermes/workflows/cron-governance.md
+++ b/.hermes/workflows/cron-governance.md
@@ -1,0 +1,28 @@
+# Cron Governance Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Read-only cron audit by default; no recursive cron creation.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.

--- a/.hermes/workflows/execute.md
+++ b/.hermes/workflows/execute.md
@@ -1,0 +1,28 @@
+# Execute Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Only approved `safe_repo_write` changes after readiness passes.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.

--- a/.hermes/workflows/observe.md
+++ b/.hermes/workflows/observe.md
@@ -1,0 +1,28 @@
+# Observe Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Read-only repository inspection and snapshot artifact writes.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.

--- a/.hermes/workflows/plan.md
+++ b/.hermes/workflows/plan.md
@@ -1,0 +1,28 @@
+# Plan Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Project-local planning artifacts under `.hermes/plans/` only.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.

--- a/.hermes/workflows/review.md
+++ b/.hermes/workflows/review.md
@@ -1,0 +1,28 @@
+# Review Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Read-only review of diffs, run artifacts, and verification evidence.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.

--- a/.hermes/workflows/verify.md
+++ b/.hermes/workflows/verify.md
@@ -1,0 +1,28 @@
+# Verify Workflow
+
+## Inputs
+
+- Current project snapshot.
+- Harness validation result.
+- Relevant canonical records.
+
+## Outputs
+
+- Canonical artifact path(s) under `.hermes/`.
+- Human summary only after canonical data exists.
+
+## Allowed Side Effects
+
+Read-only verification commands and verification artifact writes.
+
+## Stop Conditions
+
+- Required evidence is missing.
+- Action classification is blocked or approval-required.
+- Manual gate is required.
+- Harness readiness check blocks this mode.
+
+## Required Evidence
+
+- File paths or command outputs supporting every claim.
+- Explicit residual risk.


### PR DESCRIPTION
## Summary
- Add project-local .hermes profile, role prompts, workflows, schemas, and boundary ADR
- Add deterministic observe/execute readiness scripts with action preflight classification
- Keep generated state/derived artifacts ignored and cron templates inert

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/tests/test_harness.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/validate_harness.py .hermes
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-execute --action "update project-local .hermes harness artifacts"
- scripts/verify.sh

## Notes
- Execute readiness is allowed only on clean allowlisted branches.
- Manual-gated actions such as app installs, shell rc writes, cron activation, and Finder/plugin restarts remain blocked by preflight.
