### PR TITLE
chore(hermes): separate autonomy lanes

### DIFF
--- a/.hermes/README.md
+++ b/.hermes/README.md
@@ -4,6 +4,10 @@ This directory holds project-local Hermes profile and subagent role prompts.
 
 Files:
 - `profile.md` — project default behavior and scope
+- `operating-lanes.json` — separates Hermes self-improvement, project drift, and operations lanes
+- `workflows/self-improvement.md` — improve the local Hermes harness without mixing it with product work
+- `workflows/project-drift.md` — reconcile docs/metadata/CI claims with live repo facts
+- `workflows/operations.md` — run routine repo verification/branch/PR work with gates
 - `agents/research.md` — inspect and ground the problem
 - `agents/planner.md` — pick the next small objective
 - `agents/implementer.md` — make the code change

--- a/.hermes/operating-lanes.json
+++ b/.hermes/operating-lanes.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "purpose": "Keep Hermes self-improvement, project-drift detection, and repo operations as separate lanes with separate evidence and gates.",
+  "lanes": [
+    {
+      "id": "self_improvement",
+      "name": "Hermes self-improvement",
+      "purpose": "Improve the local agent harness, prompts, tests, and reusable workflows without changing goto product behavior unless explicitly selected as a repo task.",
+      "workflow": "workflows/self-improvement.md",
+      "primary_output": ".hermes source/docs/tests or a skill/script update",
+      "manual_gates": [
+        "Changing global Hermes config, credentials, providers, delivery targets, or scheduler jobs",
+        "Turning an advisory harness into an autonomous executor",
+        "Adding broad abstractions without a failing test or repeated use case"
+      ]
+    },
+    {
+      "id": "project_drift",
+      "name": "Project drift and divergence",
+      "purpose": "Detect and reconcile mismatch between docs, plans, harness metadata, generated state, CI, and live repository facts.",
+      "workflow": "workflows/project-drift.md",
+      "primary_output": "drift finding, targeted doc/metadata repair, or explicit waived mismatch",
+      "manual_gates": [
+        "Changing product goals or architecture decisions",
+        "Deleting historical evidence instead of marking it stale",
+        "Rewriting release or user-facing claims without verification"
+      ]
+    },
+    {
+      "id": "operations",
+      "name": "Project operations",
+      "purpose": "Run routine repo operations such as verification, branch/PR loops, release readiness checks, and safe maintenance with evidence and rollback boundaries.",
+      "workflow": "workflows/operations.md",
+      "primary_output": "verified branch/PR/check result, operation log, or safe stop report",
+      "manual_gates": [
+        "Release, deploy, main push, or public announcement",
+        "User/system side effects such as /Applications installs, shell rc edits, Finder restarts, sudo, service managers",
+        "Scheduler creation or modification"
+      ]
+    }
+  ]
+}

--- a/.hermes/operating-system.md
+++ b/.hermes/operating-system.md
@@ -6,6 +6,10 @@ This file defines how a future goto project commander operates. It is a convenie
 
 ## Run Sequence
 
+0. Select exactly one operating lane from `.hermes/operating-lanes.json`:
+   - self-improvement: Hermes harness/prompts/tests/runbooks only.
+   - project drift: reconcile docs/metadata/CI claims with live repo facts.
+   - operations: routine repo verification, branch/PR, CI, and maintenance work.
 1. Snapshot project state with `.hermes/scripts/snapshot_project.py`.
 2. Validate schemas and examples with `.hermes/scripts/validate_harness.py`.
 3. Check readiness with `.hermes/scripts/check_harness_ready.py`.

--- a/.hermes/profile.md
+++ b/.hermes/profile.md
@@ -21,6 +21,7 @@ Purpose:
 Default operating rules:
 - Start with evidence from the repo, not assumptions.
 - Pick the smallest high-leverage goal first.
+- Keep work in one explicit operating lane at a time: self-improvement, project drift, or operations.
 - Prefer reversible changes and mechanical verification.
 - Record exclusions or failures instead of dropping them.
 

--- a/.hermes/scripts/check_harness_ready.py
+++ b/.hermes/scripts/check_harness_ready.py
@@ -32,7 +32,7 @@ ALLOWED_EXECUTE_BRANCH_PREFIXES = ("hermes/", "feature/", "chore/", "fix/")
 ACTION_RULES = [
     ("user_or_system_side_effect", ["~/.goto", "shell rc", "~/applications", "/applications", "launchctl", "pluginkit", "pkill finder", "sudo", "finder sync", "install-app", "goto.app"]),
     ("scheduler_side_effect", ["cronjob", "cron job", "scheduled job", "recurring cron", "every hour", "every day"]),
-    ("repo_write", ["modify product/", "edit product/", "write product/", "change product/", "patch product/", "modify scripts/", "edit scripts/", "write scripts/", "change scripts/", "patch scripts/", "implement feature", "fix bug", "write .hermes", "edit .hermes", "modify .hermes", "update .hermes", "patch .hermes", "project-local .hermes", "harness artifacts", "add harness"]),
+    ("repo_write", ["modify product/", "edit product/", "write product/", "change product/", "patch product/", "modify scripts/", "edit scripts/", "write scripts/", "change scripts/", "patch scripts/", "implement feature", "fix bug", "write .hermes", "edit .hermes", "modify .hermes", "update .hermes", "patch .hermes", "project-local .hermes", "harness artifacts", "add harness", "separate self-improvement", "operating lanes"]),
 ]
 READ_ONLY_ACTION_TERMS = ["read", "inspect", "review", "observe", "list", "search", "check", "summarize"]
 

--- a/.hermes/scripts/validate_harness.py
+++ b/.hermes/scripts/validate_harness.py
@@ -11,6 +11,7 @@ import sys
 class ValidationResult:
     errors: list[str] = field(default_factory=list)
     validated_examples: int = 0
+    operating_lanes: list[dict] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
@@ -22,6 +23,12 @@ SCHEMA_BY_PREFIX = {
     "observation": "observation.schema.json",
     "decision": "decision.schema.json",
     "verification": "verification.schema.json",
+}
+
+REQUIRED_OPERATING_LANES = {
+    "self_improvement": "workflows/self-improvement.md",
+    "project_drift": "workflows/project-drift.md",
+    "operations": "workflows/operations.md",
 }
 
 
@@ -92,6 +99,41 @@ def _validate_against_schema(data: dict, schema: dict, path: Path) -> list[str]:
     return errors
 
 
+def _validate_operating_lanes(hermes_dir: Path, result: ValidationResult) -> None:
+    lanes_path = hermes_dir / "operating-lanes.json"
+    data = _load_json(lanes_path, result)
+    if data is None:
+        return
+    lanes = data.get("lanes") if isinstance(data, dict) else None
+    if not isinstance(lanes, list):
+        result.errors.append(f"{lanes_path}: missing lanes array")
+        return
+    result.operating_lanes = lanes
+    lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
+    required_lane_ids = set(REQUIRED_OPERATING_LANES)
+    missing = sorted(required_lane_ids - lane_ids)
+    extra = sorted(lane_id for lane_id in lane_ids - required_lane_ids if isinstance(lane_id, str))
+    if missing:
+        result.errors.append(f"{lanes_path}: missing required lanes {', '.join(missing)}")
+    if extra:
+        result.errors.append(f"{lanes_path}: unexpected lanes {', '.join(extra)}")
+    for index, lane in enumerate(lanes):
+        if not isinstance(lane, dict):
+            result.errors.append(f"{lanes_path}: lane {index} must be an object")
+            continue
+        for key in ("id", "name", "purpose", "workflow", "primary_output", "manual_gates"):
+            if not lane.get(key):
+                result.errors.append(f"{lanes_path}: lane {lane.get('id', index)!r} missing {key}")
+        workflow = lane.get("workflow")
+        expected_workflow = REQUIRED_OPERATING_LANES.get(lane.get("id"))
+        if expected_workflow and workflow != expected_workflow:
+            result.errors.append(
+                f"{lanes_path}: lane {lane.get('id')!r} workflow must be {expected_workflow}, got {workflow!r}"
+            )
+        if isinstance(workflow, str) and not (hermes_dir / workflow).exists():
+            result.errors.append(f"{lanes_path}: lane {lane.get('id', index)!r} workflow missing: {workflow}")
+
+
 def validate_harness(hermes_dir: Path | str = Path(".hermes")) -> ValidationResult:
     hermes_dir = Path(hermes_dir)
     result = ValidationResult()
@@ -115,6 +157,8 @@ def validate_harness(hermes_dir: Path | str = Path(".hermes")) -> ValidationResu
             continue
         result.errors.extend(_validate_against_schema(data, schema, example_path))
         result.validated_examples += 1
+
+    _validate_operating_lanes(hermes_dir, result)
 
     return result
 

--- a/.hermes/tests/test_harness.py
+++ b/.hermes/tests/test_harness.py
@@ -45,6 +45,27 @@ class HarnessTests(unittest.TestCase):
         self.assertEqual([], result.errors)
         self.assertGreaterEqual(result.validated_examples, 4)
 
+    def test_validate_harness_requires_separate_operating_lanes(self):
+        from scripts.validate_harness import validate_harness
+
+        result = validate_harness(self.repo / ".hermes")
+
+        self.assertEqual([], result.errors)
+        lanes = result.operating_lanes
+        self.assertEqual(
+            {"self_improvement", "project_drift", "operations"},
+            {lane["id"] for lane in lanes},
+        )
+        expected_workflows = {
+            "self_improvement": "workflows/self-improvement.md",
+            "project_drift": "workflows/project-drift.md",
+            "operations": "workflows/operations.md",
+        }
+        for lane in lanes:
+            self.assertEqual(expected_workflows[lane["id"]], lane["workflow"])
+            workflow_path = self.repo / ".hermes" / lane["workflow"]
+            self.assertTrue(workflow_path.exists(), lane["workflow"])
+
     def test_snapshot_detects_tests_in_live_repo(self):
         from scripts.snapshot_project import build_snapshot
 
@@ -181,6 +202,16 @@ class HarnessTests(unittest.TestCase):
         self.assertFalse(result["allowed_in_observe"])
         self.assertTrue(result["allowed_in_execute"])
         self.assertIn("modify scripts/", result["matched_terms"])
+
+    def test_preflight_classifies_lane_separation_as_repo_write(self):
+        from scripts.check_harness_ready import classify_action
+
+        result = classify_action("separate self-improvement project drift and operations lanes")
+
+        self.assertEqual("repo_write", result["classification"])
+        self.assertFalse(result["allowed_in_observe"])
+        self.assertTrue(result["allowed_in_execute"])
+        self.assertIn("separate self-improvement", result["matched_terms"])
 
     def test_preflight_blocks_user_or_system_side_effects(self):
         from scripts.check_harness_ready import classify_action

--- a/.hermes/workflows/operations.md
+++ b/.hermes/workflows/operations.md
@@ -1,0 +1,53 @@
+# Operations Lane
+
+## Purpose
+
+Run routine `goto` repository operations with evidence: verification, branch/PR loops, CI monitoring, safe merges after approved autonomy boundaries, and release-readiness checks.
+
+This lane is separate from self-improvement and drift. It changes or verifies project state; it should not quietly expand the Hermes harness or rewrite project direction during routine operations.
+
+## Inputs
+
+- Current git status, branch, and remote tracking state
+- `scripts/verify.sh` / `scripts/verify.sh --ci`
+- GitHub PR/check state when relevant
+- Harness preflight for the requested operation
+- Applicable release/branch rules from `AGENTS.md`
+
+## Allowed Side Effects
+
+- Reversible repo-local commits on non-main feature branches.
+- PR creation and CI monitoring when branch state is clean and checks pass.
+- develop merge only when the current autonomy boundary or user instruction allows it.
+
+## Manual Gates
+
+- Release, deploy, tag, main push, or public announcement.
+- Real money, account/permission/billing changes, credentials, or external messages.
+- User/system side effects: `/Applications` installs, shell rc edits, Finder/plugin restarts, `sudo`, launch agents, service managers.
+- Creating, updating, pausing, resuming, or deleting scheduler/cron jobs.
+
+## Standard Loop
+
+1. Check git status, branch, and latest commits.
+2. Run harness action preflight for the intended operation.
+3. Use a feature branch for writes.
+4. Make the smallest change.
+5. Run focused tests, then `scripts/verify.sh`; use `--ci` before merge when feasible.
+6. Use an independent review for multi-file or boundary-sensitive changes.
+7. Commit, push, open PR, watch CI, merge only inside the approved boundary.
+8. Re-check develop and rerun standard verification after merge.
+
+## Stop Conditions
+
+- Harness preflight requires a manual gate.
+- Worktree is dirty for unrelated reasons.
+- CI or local verification fails and the failure is not understood.
+- The next step belongs to self-improvement or project drift and should be split out.
+
+## Required Evidence
+
+- Commands run and their pass/fail state.
+- PR URL/check URL when applicable.
+- Final branch/status summary.
+- Explicit rollback boundary for changed repo state.

--- a/.hermes/workflows/project-drift.md
+++ b/.hermes/workflows/project-drift.md
@@ -1,0 +1,42 @@
+# Project Drift Lane
+
+## Purpose
+
+Detect and repair divergence between project truth and project descriptions: README, AGENTS.md, ADRs, `.hermes/plan.json`, workflow docs, CI configuration, generated reports, and live repo facts.
+
+This lane is separate from self-improvement and operations. Its job is reconciliation, not adding new features or running a full PR/release loop unless a small repair is selected.
+
+## Inputs
+
+- `AGENTS.md`, `README.md`, `docs/adr/`
+- `.hermes/plan.json`, `.hermes/profile.md`, `.hermes/README.md`
+- `.github/workflows/*.yml`
+- `scripts/verify.sh` and current test/build commands
+- Fresh project snapshot and drift report
+
+## Allowed Side Effects
+
+- Targeted documentation or metadata repairs that make claims match verified repo facts.
+- Small harness drift rules with tests, one rule at a time.
+- No product behavior changes unless handed off to the operations lane as a separate repo task.
+
+## Standard Loop
+
+1. Snapshot live repo facts.
+2. Compare docs/metadata/CI claims against live facts.
+3. Classify each mismatch as repair, waive, or escalate.
+4. Repair the smallest stale claim or metadata field.
+5. Verify with drift report, harness tests, and relevant repo checks.
+6. Preserve history: mark stale/waived evidence instead of silently deleting context.
+
+## Stop Conditions
+
+- The mismatch implies a product goal or architecture change rather than a factual doc/metadata repair.
+- Evidence is insufficient to decide which source is correct.
+- Fixing the drift would require deleting historical records or changing release/user-facing claims without verification.
+
+## Required Evidence
+
+- Exact file path and line or generated report field for each mismatch.
+- The live command or file evidence used as truth.
+- A post-repair drift/harness result.

--- a/.hermes/workflows/self-improvement.md
+++ b/.hermes/workflows/self-improvement.md
@@ -1,0 +1,43 @@
+# Self-Improvement Lane
+
+## Purpose
+
+Improve Hermes itself for this repository: local harness code, validation tests, role prompts, runbooks, and reusable skills/scripts.
+
+This lane is separate from product work. A self-improvement run must not claim that `goto` product behavior improved unless product files were intentionally changed and product verification passed.
+
+## Inputs
+
+- `.hermes/operating-lanes.json`
+- Current harness reports under `.hermes/derived/`
+- Failing or missing harness tests
+- Repeated manual steps from recent work
+- User corrections about agent behavior
+
+## Allowed Side Effects
+
+- Repo-local `.hermes/` source/docs/tests changes on a feature branch.
+- Skill patch/create only when the learned procedure is reusable beyond this one repo.
+- No scheduler, credential, provider, global config, or delivery-target changes without manual gate.
+
+## Standard Loop
+
+1. State the self-improvement hypothesis.
+2. Add or update the smallest harness/test/doc check that exposes the gap.
+3. Make the minimal repo-local improvement.
+4. Run `.hermes` tests and aggregate observe harness.
+5. Run product verification if the improvement is wired into product verification or touches shared scripts.
+6. Record the distinction between agent improvement and product behavior.
+
+## Stop Conditions
+
+- The proposed change would modify global Hermes state, credentials, providers, delivery, cron jobs, or user/system state.
+- The change broadens the harness without a concrete failure, repeated manual step, or user correction.
+- The local harness is dirty or generated artifacts would be committed.
+
+## Required Evidence
+
+- Failing test or explicit gap before the change, when practical.
+- Passing `.hermes/tests/test_harness.py` after the change.
+- Passing `scripts/verify.sh` when standard verification is affected.
+- `git status --short --ignored .hermes` showing only intended source changes and ignored generated state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,16 @@ scripts/generate_macos_project.rb
 - `develop` pushes and PRs should go through the gate runner workflow.
 - Merge `develop` into `main` only when you want to cut a deployment or release.
 
+## Hermes operating lanes
+
+For repo-local Hermes work, select exactly one lane from `.hermes/operating-lanes.json` before acting:
+
+- `self_improvement` — improve `.hermes` harness, prompts, tests, runbooks, or reusable skills without implying product behavior changed.
+- `project_drift` — reconcile docs, metadata, CI, and generated-state claims with live repository facts.
+- `operations` — run routine verification, branch/PR, CI, merge, and release-readiness work with the gates above.
+
+Do not mix lane objectives in one change unless the handoff is explicit and separately verified.
+
 ## Architecture rules
 
 1. `goto` stays separate from `Goto.app`.


### PR DESCRIPTION
## Summary
- add explicit self_improvement, project_drift, and operations lanes for repo-local Hermes work
- validate required lane ids and exact workflow mappings in the harness
- document lane selection in project guidance and workflows

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/tests/test_harness.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/validate_harness.py .hermes
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --action "separate self-improvement project drift and operations lanes"
- scripts/verify.sh --ci