### PR TITLE
chore(hermes): require lane-aware harness checks

### DIFF
--- a/.hermes/README.md
+++ b/.hermes/README.md
@@ -22,13 +22,14 @@ Recommended roles: research, planner, implementer, verifier, reviewer
 Use the aggregate check first. It is the safest current entry point because it runs validation, snapshot, drift, and readiness together without enabling execution:
 
 ```bash
-PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --lane operations
 ```
 
 Expected state on `main`:
 
 ```text
 operating_state=stable_observe_only
+lane=operations status=selected
 observe=pass exit_code=0
 execute=blocked exit_code=10
 require=observe
@@ -37,7 +38,7 @@ require=observe
 Use the stricter form when a caller must prove execution readiness:
 
 ```bash
-PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-execute
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-execute --lane operations
 ```
 
 Expected state on `main`: same report, but the command exits non-zero because execution is blocked.
@@ -45,7 +46,7 @@ Expected state on `main`: same report, but the command exits non-zero because ex
 Attach a requested action to the same report before doing any work:
 
 ```bash
-PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --action "read README.md"
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --lane operations --action "read README.md"
 ```
 
 The small action gate in `check_harness_ready.py` currently distinguishes:

--- a/.hermes/scripts/run_harness_checks.py
+++ b/.hermes/scripts/run_harness_checks.py
@@ -44,7 +44,47 @@ def _safe_next_action(execute_status: str, preflight: dict) -> str:
     return "execute_allowed_by_harness"
 
 
-def run_harness_checks(repo: Path | str = Path("."), action_description: str | None = None) -> dict:
+def _lane_report(validation, lane: str | None) -> dict:
+    if lane is None:
+        lane_id = "operations"
+    else:
+        lane_id = lane.strip()
+    lanes = {item.get("id"): item for item in validation.operating_lanes if isinstance(item, dict)}
+    if not lane_id:
+        return {
+            "status": "invalid",
+            "id": lane,
+            "name": None,
+            "workflow": None,
+            "issues": [{
+                "code": "empty_operating_lane",
+                "severity": "critical",
+                "message": "Operating lane must be a non-empty lane id",
+            }],
+        }
+    selected = lanes.get(lane_id)
+    if selected:
+        return {
+            "status": "selected",
+            "id": lane_id,
+            "name": selected.get("name"),
+            "workflow": selected.get("workflow"),
+            "issues": [],
+        }
+    return {
+        "status": "invalid",
+        "id": lane_id,
+        "name": None,
+        "workflow": None,
+        "issues": [{
+            "code": "unknown_operating_lane",
+            "severity": "critical",
+            "message": f"Unknown operating lane {lane_id!r}; allowed lanes are {sorted(lanes)}",
+        }],
+    }
+
+
+def run_harness_checks(repo: Path | str = Path("."), action_description: str | None = None, lane: str | None = None) -> dict:
     repo = Path(repo).resolve()
     validation = validate_harness(repo / ".hermes")
     snapshot = build_snapshot(repo)
@@ -52,6 +92,7 @@ def run_harness_checks(repo: Path | str = Path("."), action_description: str | N
     observe = evaluate_readiness(repo, mode="observe")
     execute = evaluate_readiness(repo, mode="execute")
     preflight = classify_action(action_description or "observe harness status")
+    lane_selection = _lane_report(validation, lane)
 
     validate_status = "pass" if validation.ok else "fail"
     drift_status = "pass" if drift.get("summary", {}).get("critical", 0) == 0 else "fail"
@@ -91,16 +132,20 @@ def run_harness_checks(repo: Path | str = Path("."), action_description: str | N
                 "issues": execute.issues,
             },
         },
+        "lane": lane_selection,
         "preflight": preflight,
         "summary": {
             "operating_state": _operating_state(observe_status, execute_status),
             "safe_next_action": _safe_next_action(execute_status, preflight),
+            "lane": lane_selection.get("id"),
         },
     }
 
 
 def aggregate_exit_code(report: dict, require: str = "observe") -> int:
     if require not in {"observe", "execute"}:
+        return 20
+    if report.get("lane", {}).get("status") == "invalid":
         return 20
     if report["steps"]["validate_harness"]["status"] == "fail":
         return 20
@@ -123,6 +168,7 @@ def main(argv: list[str] | None = None) -> int:
     argv = argv or sys.argv[1:]
     require = "observe"
     action_description = None
+    lane = None
     paths = []
     index = 0
     while index < len(argv):
@@ -137,16 +183,23 @@ def main(argv: list[str] | None = None) -> int:
                 return 20
             action_description = argv[index + 1]
             index += 1
+        elif arg == "--lane":
+            if index + 1 >= len(argv):
+                print("ERROR --lane requires an operating lane id", file=sys.stderr)
+                return 20
+            lane = argv[index + 1]
+            index += 1
         else:
             paths.append(arg)
         index += 1
     repo = Path(paths[0]) if paths else Path(".")
-    report = run_harness_checks(repo, action_description=action_description)
+    report = run_harness_checks(repo, action_description=action_description, lane=lane)
     out = repo / ".hermes" / "derived" / "harness-check-report.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(report, indent=2) + "\n")
     print(str(out))
     print(f"operating_state={report['summary']['operating_state']}")
+    print(f"lane={report['summary']['lane']} status={report['lane']['status']}")
     observe = report["readiness"]["observe"]
     execute = report["readiness"]["execute"]
     print(f"observe={observe['status']} exit_code={observe['exit_code']}")

--- a/.hermes/tests/test_harness.py
+++ b/.hermes/tests/test_harness.py
@@ -240,6 +240,33 @@ class HarnessTests(unittest.TestCase):
         self.assertEqual("read_only", report["preflight"]["classification"])
         self.assertTrue(report["preflight"]["allowed_in_observe"])
 
+    def test_aggregate_report_records_selected_operating_lane(self):
+        from scripts.run_harness_checks import run_harness_checks
+
+        report = run_harness_checks(self.repo, lane="project_drift")
+
+        self.assertEqual("project_drift", report["lane"]["id"])
+        self.assertEqual("workflows/project-drift.md", report["lane"]["workflow"])
+        self.assertEqual("project_drift", report["summary"]["lane"])
+
+    def test_invalid_lane_blocks_aggregate_report(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        report = run_harness_checks(self.repo, lane="mixed")
+
+        self.assertEqual("invalid", report["lane"]["status"])
+        self.assertEqual("unknown_operating_lane", report["lane"]["issues"][0]["code"])
+        self.assertEqual(20, aggregate_exit_code(report, require="observe"))
+
+    def test_empty_explicit_lane_blocks_aggregate_report(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        report = run_harness_checks(self.repo, lane="")
+
+        self.assertEqual("invalid", report["lane"]["status"])
+        self.assertEqual("empty_operating_lane", report["lane"]["issues"][0]["code"])
+        self.assertEqual(20, aggregate_exit_code(report, require="observe"))
+
     def test_aggregate_report_classifies_requested_action(self):
         from scripts.run_harness_checks import run_harness_checks
 

--- a/product/cli/test/native-scripts.test.js
+++ b/product/cli/test/native-scripts.test.js
@@ -146,6 +146,7 @@ test('verify script runs the standard local gates in order', async () => {
   ]);
   assert.match(calls[0], /--test/);
   assert.match(calls[3], /--require-observe/);
+  assert.match(calls[3], /--lane operations/);
   assert.doesNotMatch(calls.join('\n'), /^build-app/m);
 });
 
@@ -192,6 +193,7 @@ test('verify script ci mode adds the app build gate and Finder appex check', asy
     'check-finder-appex',
   ]);
   assert.match(calls[3], /--require-observe/);
+  assert.match(calls[3], /--lane operations/);
 });
 
 test('build-app script keeps Xcode build outputs inside the repository', async () => {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -62,7 +62,7 @@ printf '==> Native unit tests\n' >&2
 "$native_test_script"
 
 printf '==> Hermes harness checks\n' >&2
-PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$REPO_ROOT/.hermes" "$hermes_harness_script" --require-observe --action "verify repository gates" "$REPO_ROOT"
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$REPO_ROOT/.hermes" "$hermes_harness_script" --require-observe --lane operations --action "verify repository gates" "$REPO_ROOT"
 
 if [[ "$mode" == "ci" ]]; then
   printf '==> Native app build\n' >&2


### PR DESCRIPTION
## Summary
- add --lane support to the aggregate Hermes harness check
- record selected lane in reports and block invalid/empty explicit lanes
- run standard repository verification under the explicit operations lane

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/tests/test_harness.py
- node --test product/cli/test/native-scripts.test.js --test-name-pattern "verify script"
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --lane '' --action "observe lane validation"; test 0 -eq 20
- scripts/verify.sh --ci