### PR TITLE
chore(hermes): enforce lane file boundaries

### DIFF
--- a/.hermes/README.md
+++ b/.hermes/README.md
@@ -49,6 +49,14 @@ Attach a requested action to the same report before doing any work:
 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/run_harness_checks.py --require-observe --lane operations --action "read README.md"
 ```
 
+The selected lane also evaluates dirty/untracked paths against `allowed_paths` and `forbidden_paths` in `operating-lanes.json`. Boundary violations are reported under `lane.boundary` and make the aggregate command exit 10, so a self-improvement run cannot silently include product-source edits.
+
+When verifying a branch whose source edits belong to a non-operations lane, set the verification lane explicitly:
+
+```bash
+GOTO_HERMES_VERIFY_LANE=self_improvement scripts/verify.sh --ci
+```
+
 The small action gate in `check_harness_ready.py` currently distinguishes:
 
 - `read_only` — observe-safe

--- a/.hermes/operating-lanes.json
+++ b/.hermes/operating-lanes.json
@@ -8,6 +8,22 @@
       "purpose": "Improve the local agent harness, prompts, tests, and reusable workflows without changing goto product behavior unless explicitly selected as a repo task.",
       "workflow": "workflows/self-improvement.md",
       "primary_output": ".hermes source/docs/tests or a skill/script update",
+      "allowed_paths": [
+        ".hermes/**",
+        "scripts/verify.sh",
+        "product/cli/test/native-scripts.test.js"
+      ],
+      "forbidden_paths": [
+        "product/cli/src/**",
+        "product/cli/bin/**",
+        "product/cli/shell/**",
+        "product/core/**",
+        "product/macos/Goto/**",
+        "product/macos/GotoFinderSync/**",
+        ".github/**",
+        "docs/**",
+        "README.md"
+      ],
       "manual_gates": [
         "Changing global Hermes config, credentials, providers, delivery targets, or scheduler jobs",
         "Turning an advisory harness into an autonomous executor",
@@ -20,6 +36,24 @@
       "purpose": "Detect and reconcile mismatch between docs, plans, harness metadata, generated state, CI, and live repository facts.",
       "workflow": "workflows/project-drift.md",
       "primary_output": "drift finding, targeted doc/metadata repair, or explicit waived mismatch",
+      "allowed_paths": [
+        "README.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "docs/**",
+        ".github/**",
+        ".hermes/**",
+        "scripts/verify.sh",
+        "product/cli/test/native-scripts.test.js"
+      ],
+      "forbidden_paths": [
+        "product/cli/src/**",
+        "product/cli/bin/**",
+        "product/cli/shell/**",
+        "product/core/**",
+        "product/macos/Goto/**",
+        "product/macos/GotoFinderSync/**"
+      ],
       "manual_gates": [
         "Changing product goals or architecture decisions",
         "Deleting historical evidence instead of marking it stale",
@@ -32,6 +66,20 @@
       "purpose": "Run routine repo operations such as verification, branch/PR loops, release readiness checks, and safe maintenance with evidence and rollback boundaries.",
       "workflow": "workflows/operations.md",
       "primary_output": "verified branch/PR/check result, operation log, or safe stop report",
+      "allowed_paths": [
+        ".hermes/derived/**",
+        ".hermes/state/**",
+        ".github/**",
+        "scripts/verify.sh"
+      ],
+      "forbidden_paths": [
+        "product/cli/src/**",
+        "product/cli/bin/**",
+        "product/cli/shell/**",
+        "product/core/**",
+        "product/macos/Goto/**",
+        "product/macos/GotoFinderSync/**"
+      ],
       "manual_gates": [
         "Release, deploy, main push, or public announcement",
         "User/system side effects such as /Applications installs, shell rc edits, Finder restarts, sudo, service managers",

--- a/.hermes/scripts/run_harness_checks.py
+++ b/.hermes/scripts/run_harness_checks.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import fnmatch
 import json
+import subprocess
 import sys
 from datetime import datetime, timezone
 
@@ -56,6 +58,8 @@ def _lane_report(validation, lane: str | None) -> dict:
             "id": lane,
             "name": None,
             "workflow": None,
+            "allowed_paths": [],
+            "forbidden_paths": [],
             "issues": [{
                 "code": "empty_operating_lane",
                 "severity": "critical",
@@ -69,6 +73,8 @@ def _lane_report(validation, lane: str | None) -> dict:
             "id": lane_id,
             "name": selected.get("name"),
             "workflow": selected.get("workflow"),
+            "allowed_paths": selected.get("allowed_paths", []),
+            "forbidden_paths": selected.get("forbidden_paths", []),
             "issues": [],
         }
     return {
@@ -76,11 +82,80 @@ def _lane_report(validation, lane: str | None) -> dict:
         "id": lane_id,
         "name": None,
         "workflow": None,
+        "allowed_paths": [],
+        "forbidden_paths": [],
         "issues": [{
             "code": "unknown_operating_lane",
             "severity": "critical",
             "message": f"Unknown operating lane {lane_id!r}; allowed lanes are {sorted(lanes)}",
         }],
+    }
+
+
+def _changed_files(repo: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain", "--untracked-files=all"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return []
+    if result.returncode != 0:
+        return []
+    files: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            old_path, new_path = path.split(" -> ", 1)
+            files.append(old_path)
+            files.append(new_path)
+        else:
+            files.append(path)
+    return sorted(set(files))
+
+
+def _matches_path(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def _boundary_report(repo: Path, lane_selection: dict) -> dict:
+    changed = _changed_files(repo)
+    allowed = lane_selection.get("allowed_paths") or []
+    forbidden = lane_selection.get("forbidden_paths") or []
+    issues = []
+    if lane_selection.get("status") != "selected":
+        return {
+            "status": "not_evaluated",
+            "changed_files": changed,
+            "allowed_paths": allowed,
+            "forbidden_paths": forbidden,
+            "issues": [],
+        }
+    for path in changed:
+        if _matches_path(path, forbidden):
+            issues.append({
+                "code": "lane_path_forbidden",
+                "severity": "critical",
+                "path": path,
+                "message": f"{path} is forbidden for lane {lane_selection.get('id')}",
+            })
+        elif allowed and not _matches_path(path, allowed):
+            issues.append({
+                "code": "lane_path_not_allowed",
+                "severity": "critical",
+                "path": path,
+                "message": f"{path} is outside allowed paths for lane {lane_selection.get('id')}",
+            })
+    return {
+        "status": "blocked" if issues else "pass",
+        "changed_files": changed,
+        "allowed_paths": allowed,
+        "forbidden_paths": forbidden,
+        "issues": issues,
     }
 
 
@@ -93,6 +168,7 @@ def run_harness_checks(repo: Path | str = Path("."), action_description: str | N
     execute = evaluate_readiness(repo, mode="execute")
     preflight = classify_action(action_description or "observe harness status")
     lane_selection = _lane_report(validation, lane)
+    lane_selection["boundary"] = _boundary_report(repo, lane_selection)
 
     validate_status = "pass" if validation.ok else "fail"
     drift_status = "pass" if drift.get("summary", {}).get("critical", 0) == 0 else "fail"
@@ -147,6 +223,8 @@ def aggregate_exit_code(report: dict, require: str = "observe") -> int:
         return 20
     if report.get("lane", {}).get("status") == "invalid":
         return 20
+    if report.get("lane", {}).get("boundary", {}).get("status") == "blocked":
+        return 10
     if report["steps"]["validate_harness"]["status"] == "fail":
         return 20
     if report["steps"]["drift_report"]["status"] == "fail":

--- a/.hermes/scripts/validate_harness.py
+++ b/.hermes/scripts/validate_harness.py
@@ -121,9 +121,23 @@ def _validate_operating_lanes(hermes_dir: Path, result: ValidationResult) -> Non
         if not isinstance(lane, dict):
             result.errors.append(f"{lanes_path}: lane {index} must be an object")
             continue
-        for key in ("id", "name", "purpose", "workflow", "primary_output", "manual_gates"):
-            if not lane.get(key):
+        for key in (
+            "id",
+            "name",
+            "purpose",
+            "workflow",
+            "primary_output",
+            "allowed_paths",
+            "forbidden_paths",
+            "manual_gates",
+        ):
+            if key not in lane or lane.get(key) in (None, ""):
                 result.errors.append(f"{lanes_path}: lane {lane.get('id', index)!r} missing {key}")
+        for key in ("allowed_paths", "forbidden_paths", "manual_gates"):
+            if key in lane and not isinstance(lane.get(key), list):
+                result.errors.append(f"{lanes_path}: lane {lane.get('id', index)!r} {key} must be an array")
+            elif key in lane and any(not isinstance(item, str) or not item for item in lane.get(key, [])):
+                result.errors.append(f"{lanes_path}: lane {lane.get('id', index)!r} {key} must contain non-empty strings")
         workflow = lane.get("workflow")
         expected_workflow = REQUIRED_OPERATING_LANES.get(lane.get("id"))
         if expected_workflow and workflow != expected_workflow:

--- a/.hermes/tests/test_harness.py
+++ b/.hermes/tests/test_harness.py
@@ -65,6 +65,9 @@ class HarnessTests(unittest.TestCase):
             self.assertEqual(expected_workflows[lane["id"]], lane["workflow"])
             workflow_path = self.repo / ".hermes" / lane["workflow"]
             self.assertTrue(workflow_path.exists(), lane["workflow"])
+            self.assertIsInstance(lane.get("allowed_paths"), list, lane["id"])
+            self.assertIsInstance(lane.get("forbidden_paths"), list, lane["id"])
+            self.assertTrue(lane["allowed_paths"], lane["id"])
 
     def test_snapshot_detects_tests_in_live_repo(self):
         from scripts.snapshot_project import build_snapshot
@@ -248,6 +251,49 @@ class HarnessTests(unittest.TestCase):
         self.assertEqual("project_drift", report["lane"]["id"])
         self.assertEqual("workflows/project-drift.md", report["lane"]["workflow"])
         self.assertEqual("project_drift", report["summary"]["lane"])
+
+    def test_lane_boundaries_block_self_improvement_product_changes(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="hermes/test")
+        with temp:
+            product_file = repo / "product" / "cli" / "src" / "index.js"
+            product_file.parent.mkdir(parents=True)
+            product_file.write_text("export const changed = true;\n")
+            report = run_harness_checks(repo, lane="self_improvement")
+
+        boundary = report["lane"]["boundary"]
+        self.assertEqual("blocked", boundary["status"])
+        self.assertIn("product/cli/src/index.js", boundary["changed_files"])
+        self.assertEqual("lane_path_forbidden", boundary["issues"][0]["code"])
+        self.assertEqual(10, aggregate_exit_code(report, require="observe"))
+
+    def test_lane_boundaries_include_rename_sources_and_destinations(self):
+        from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks
+
+        temp, repo = self._temp_repo_with_valid_harness(git=True, branch="hermes/test")
+        with temp:
+            product_file = repo / "product" / "cli" / "src" / "index.js"
+            product_file.parent.mkdir(parents=True)
+            product_file.write_text("export const changed = false;\n")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.run(["git", "commit", "-m", "add product file"], cwd=repo, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            destination = repo / ".hermes" / "moved-index.js"
+            subprocess.run(
+                ["git", "mv", "product/cli/src/index.js", str(destination.relative_to(repo))],
+                cwd=repo,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            report = run_harness_checks(repo, lane="self_improvement")
+
+        boundary = report["lane"]["boundary"]
+        self.assertEqual("blocked", boundary["status"])
+        self.assertIn("product/cli/src/index.js", boundary["changed_files"])
+        self.assertIn(".hermes/moved-index.js", boundary["changed_files"])
+        self.assertEqual("lane_path_forbidden", boundary["issues"][0]["code"])
+        self.assertEqual(10, aggregate_exit_code(report, require="observe"))
 
     def test_invalid_lane_blocks_aggregate_report(self):
         from scripts.run_harness_checks import aggregate_exit_code, run_harness_checks

--- a/product/cli/test/native-scripts.test.js
+++ b/product/cli/test/native-scripts.test.js
@@ -131,6 +131,7 @@ test('verify script runs the standard local gates in order', async () => {
       GOTO_NATIVE_TYPECHECK_SCRIPT: typecheckPath,
       GOTO_NATIVE_TEST_SCRIPT: testNativePath,
       GOTO_HERMES_HARNESS_SCRIPT: harnessPath,
+      GOTO_HERMES_VERIFY_LANE: 'operations',
       GOTO_BUILD_APP_SCRIPT: buildAppPath,
     },
   });
@@ -148,6 +149,41 @@ test('verify script runs the standard local gates in order', async () => {
   assert.match(calls[3], /--require-observe/);
   assert.match(calls[3], /--lane operations/);
   assert.doesNotMatch(calls.join('\n'), /^build-app/m);
+});
+
+test('verify script can select a non-default Hermes lane via environment', async () => {
+  const fakeBinDir = await createTempDir('goto-verify-lane-bin-');
+  const logPath = path.join(fakeBinDir, 'verify.log');
+  const nodePath = path.join(fakeBinDir, 'node');
+  const typecheckPath = path.join(fakeBinDir, 'typecheck-native.sh');
+  const testNativePath = path.join(fakeBinDir, 'test-native.sh');
+  const harnessPath = path.join(fakeBinDir, 'run-harness-checks.py');
+  const buildAppPath = path.join(fakeBinDir, 'build-app.sh');
+  const scriptPath = path.join(projectRoot, 'scripts/verify.sh');
+
+  await writeExecutable(nodePath, appendCommandScript(logPath, 'node'));
+  await writeExecutable(typecheckPath, appendCommandScript(logPath, 'typecheck-native'));
+  await writeExecutable(testNativePath, appendCommandScript(logPath, 'test-native'));
+  await writeExecutable(harnessPath, appendCommandScript(logPath, 'harness'));
+  await writeExecutable(buildAppPath, appendCommandScript(logPath, 'build-app'));
+
+  const result = await runProcess('bash', [scriptPath], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      GOTO_NODE_BIN: nodePath,
+      GOTO_NATIVE_TYPECHECK_SCRIPT: typecheckPath,
+      GOTO_NATIVE_TEST_SCRIPT: testNativePath,
+      GOTO_HERMES_HARNESS_SCRIPT: harnessPath,
+      GOTO_HERMES_VERIFY_LANE: 'self_improvement',
+      GOTO_BUILD_APP_SCRIPT: buildAppPath,
+    },
+  });
+
+  const calls = (await fs.readFile(logPath, 'utf8')).trim().split('\n');
+
+  assert.equal(result.code, 0);
+  assert.match(calls[3], /--lane self_improvement/);
 });
 
 test('verify script ci mode adds the app build gate and Finder appex check', async () => {
@@ -176,6 +212,7 @@ test('verify script ci mode adds the app build gate and Finder appex check', asy
       GOTO_NATIVE_TYPECHECK_SCRIPT: typecheckPath,
       GOTO_NATIVE_TEST_SCRIPT: testNativePath,
       GOTO_HERMES_HARNESS_SCRIPT: harnessPath,
+      GOTO_HERMES_VERIFY_LANE: 'operations',
       GOTO_BUILD_APP_SCRIPT: buildAppPath,
       GOTO_FINDER_APPEX_CHECK_SCRIPT: checkFinderPath,
     },

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -16,6 +16,7 @@ Runs the local verification harness.
 
 Modes:
   --standard  Node tests, native typecheck/tests, and Hermes observe harness (default)
+              Set GOTO_HERMES_VERIFY_LANE to verify a non-operations lane branch.
   --ci        Standard checks plus a release app build and Finder appex validation
   --help      Show this help
 USAGE
@@ -51,6 +52,7 @@ native_test_script="${GOTO_NATIVE_TEST_SCRIPT:-$SCRIPT_DIR/test-native.sh}"
 build_app_script="${GOTO_BUILD_APP_SCRIPT:-$SCRIPT_DIR/build-app.sh}"
 finder_appex_check_script="${GOTO_FINDER_APPEX_CHECK_SCRIPT:-$SCRIPT_DIR/check-finder-appex.sh}"
 hermes_harness_script="${GOTO_HERMES_HARNESS_SCRIPT:-$REPO_ROOT/.hermes/scripts/run_harness_checks.py}"
+hermes_verify_lane="${GOTO_HERMES_VERIFY_LANE:-operations}"
 
 printf '==> Node CLI tests\n' >&2
 "$node_bin" --test "$REPO_ROOT"/product/cli/test/*.test.js
@@ -62,7 +64,7 @@ printf '==> Native unit tests\n' >&2
 "$native_test_script"
 
 printf '==> Hermes harness checks\n' >&2
-PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$REPO_ROOT/.hermes" "$hermes_harness_script" --require-observe --lane operations --action "verify repository gates" "$REPO_ROOT"
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$REPO_ROOT/.hermes" "$hermes_harness_script" --require-observe --lane "$hermes_verify_lane" --action "verify repository gates" "$REPO_ROOT"
 
 if [[ "$mode" == "ci" ]]; then
   printf '==> Native app build\n' >&2


### PR DESCRIPTION
## Summary
- add lane allowed/forbidden path boundaries to operating-lanes.json
- report lane boundary status in run_harness_checks and block violations
- allow scripts/verify.sh to select a non-default Hermes lane through GOTO_HERMES_VERIFY_LANE

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/tests/test_harness.py
- node --test product/cli/test/native-scripts.test.js --test-name-pattern "verify script"
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.hermes python3 .hermes/scripts/validate_harness.py .hermes
- GOTO_HERMES_VERIFY_LANE=self_improvement scripts/verify.sh --ci
- scripts/verify.sh

## Review
- blocker review found rename-source bypass; fixed with regression test
- post-fix review passed