### PR TITLE
ci(release): pin runner to macos-15 for Xcode 16 project format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary
- Release runs for PR #13 and PR #14 failed because the macos-14 runner ships Xcode 15.4, which cannot read `Goto.xcodeproj` after `xcodegen` started emitting project file format 77 on the local Xcode 16 host.
- Bumping the runner to `macos-15` (Xcode 16) so the workflow can open and build the regenerated project.

## Test plan
- [ ] Merge to main → confirm the `Release` workflow run succeeds.
- [ ] Verify a new patch tag (`vX.Y.Z`) is created and the GitHub Release attaches `Goto-vX.Y.Z.dmg` and `goto-cli-vX.Y.Z.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)