### PR TITLE
feat(cli): prefix color, f filter, pattern prefix + ship-goto skill

### DIFF
--- a/.claude/skills/ship-goto/SKILL.md
+++ b/.claude/skills/ship-goto/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: ship-goto
+description: Goto 프로젝트의 출하 파이프라인. 사용자가 "/ship-goto", "출시", "릴리즈 해줘", "정리하고 배포", "ship it" 같은 표현으로 정리→문서→로컬 배포→커밋·PR 전체 흐름을 요청할 때 자동 로드한다. 단계별로 사용자 승인을 받으며 진행하고, 절대 사용자 승인 없이 destructive 동작(파일 삭제, push, PR 생성)을 수행하지 않는다.
+---
+
+# /ship-goto — Goto 출하 파이프라인
+
+이 스킬은 Goto 프로젝트(`~/workspace/inchan/goto`)에 한정한 출하 절차를 안내한다.
+브랜치 정책상 `develop` 이 작업 브랜치이며 `main` 푸시는 PR을 통해서만 일어난다.
+`main` 으로 머지되면 GitHub Actions(`.github/workflows/release.yml`)가 자동으로 패치 버전 릴리즈를 만든다.
+
+## 실행 원칙
+
+- **4단계 순차**: 정리 → 문서 → 빌드/배포 → 커밋·푸시·PR
+- **각 단계 시작 전 사용자 확인** (변경 범위 보고 + Y/N)
+- **destructive 동작은 사용자 명시 승인 후에만**:
+  - 파일 삭제, `git push`, `gh pr create`, `git reset --hard` 등
+- 단계 도중 실패하면 다음 단계로 넘어가지 않고 보고 후 사용자 판단을 기다린다
+- 브랜치는 항상 `develop` 위에서만 작업한다. `main` 직접 푸시 금지
+
+## 사전 점검 (Stage 0)
+
+다음을 병렬로 수집하고 보고한다:
+
+```bash
+git status
+git rev-parse --abbrev-ref HEAD
+git log --oneline origin/main..HEAD
+git log --oneline origin/develop..HEAD 2>/dev/null
+gh auth status 2>&1 | head -3
+```
+
+- 현재 브랜치가 `develop` 인지 확인. 아니라면 사용자에게 전환 여부 질문
+- 작업트리 dirty 여부 보고
+- `gh` 인증 상태 확인. 미인증 시 사용자에게 `gh auth login` 안내 후 중단
+
+## Stage 1 — 정리
+
+### 스캔 항목
+
+병렬로 수행하고 결과를 군대식 보고서로 요약한다.
+
+```bash
+# Swift unused declarations / TODO / FIXME / 죽은 import
+grep -rn "TODO\|FIXME\|XXX\|HACK" Shared GotoCLI GotoApp GotoFinderSync GotoLauncher 2>/dev/null
+grep -rn "^import " Shared GotoCLI GotoApp 2>/dev/null
+
+# 빌드 산출물·캐시·임시파일
+ls -la build/ DerivedData/ .build/ 2>/dev/null
+find . -name '*.bak.*' -not -path './build/*' -not -path './.git/*' 2>/dev/null
+find . -name '.DS_Store' 2>/dev/null
+
+# wiki/scripts 중 더 이상 참조되지 않는 파일
+ls wiki/summaries/ scripts/ 2>/dev/null
+```
+
+### 정리 정책
+
+- **빌드 산출물**(`build/`, `DerivedData/`)은 .gitignore 대상이면 그대로 둔다. 추적 중이면 사용자에게 제거 제안
+- **`.bak.*` 백업 파일**: `~/.local/bin/goto.bak.*` 같은 사용자 환경 백업은 건드리지 않는다. 레포 내부의 `*.bak` 만 제거 후보로 보고
+- **사용되지 않는 wiki/summaries/문서**: 본문에 링크되지 않은 항목을 후보로 제시. **자동 삭제 금지** — 사용자 승인 필수
+- **죽은 코드**:
+  - Swift `private` 심볼인데 참조 0개 → 후보 보고
+  - 미사용 `import` → grep 으로 의심 후보 보고
+  - 빈 함수, 빈 catch, `_ = ` 의미 없는 무시 패턴 보고
+- **주석 정리**:
+  - 코드와 어긋난 한글 주석, 자기설명적 주석, 옛 버전(`Goto3` 등) 잔재 보고
+  - **WHY 가 적힌 주석은 보존**
+
+### 출력 형식
+
+```
+## Stage 1 정리 후보
+
+[자동 삭제 가능]
+- <path> — <이유>
+
+[사용자 확인 필요]
+- <path> — <이유>
+
+[보존]
+- <path> — <이유>
+```
+
+사용자에게 `AskUserQuestion` 으로 삭제 범위 확정한 뒤 실행한다.
+
+## Stage 2 — 문서 업데이트
+
+### 점검 대상
+
+- `README.md` — 현재 기능 설명이 최신인지
+- `AGENTS.md` — 변경된 정책 반영 필요한지
+- `wiki/index.md`, `wiki/SCHEMA.md` — 새 기능(prefix 색상, 패턴 매칭, `f` 필터 등) 반영 여부
+- `wiki/summaries/` — 최근 PR 단위 요약 추가 여부
+- `wiki/log.md` — 변경 로그 누적 정책 따르는지
+
+### 작업 정책
+
+- 발견된 누락만 보고하고, **추가/수정 패치를 보여준 뒤 적용 여부를 사용자에게 묻는다**
+- 새 wiki summary 가 필요해 보이면 파일명·제목 후보를 제시
+- 문서 톤은 기존 한국어 톤 + 군대식 요약을 유지
+
+## Stage 3 — 빌드 / 로컬 배포
+
+```bash
+xcodebuild -project Goto.xcodeproj -scheme GotoCLI -configuration Release \
+    -derivedDataPath ./build build 2>&1 | tail -5
+```
+
+BUILD SUCCEEDED 확인 후:
+
+```bash
+cp ~/.local/bin/goto ~/.local/bin/goto.bak.$(date +%Y%m%d%H%M%S) 2>/dev/null
+cp ./build/Build/Products/Release/goto ~/.local/bin/goto
+codesign --force --sign - ~/.local/bin/goto
+~/.local/bin/goto --help | head -3
+```
+
+- 사용자에게 "전체 앱(`./install.sh`)도 함께 설치할지" 옵션 제공
+  - 기본은 CLI 단독 배포만 수행
+  - `./install.sh` 호출 시 sudo 권한과 `/Applications/Goto.app` 영향 사용자 명시 후 진행
+- 빌드 실패 시 즉시 중단하고 에러 보고
+
+## Stage 4 — 커밋 · 푸시 · PR
+
+### 4-1 커밋
+
+```bash
+git status
+git diff --stat
+git log --oneline -5
+```
+
+- 변경 단위로 커밋 메시지 초안 작성 (Conventional Commits 권장: `feat`, `fix`, `chore`, `docs`, `refactor`, `ci`)
+- **메시지에 Claude Code 서명을 임의로 추가하지 않는다** (사용자 레포 컨벤션 존중 — 최근 커밋 로그 패턴 따른다)
+- 사용자 승인 후 커밋:
+
+```bash
+git add <specific files>   # NEVER use `git add -A`
+git commit -m "$(cat <<'EOF'
+<title>
+
+<body>
+EOF
+)"
+```
+
+### 4-2 푸시 — 사용자 명시 승인 후
+
+```bash
+git push origin develop
+```
+
+### 4-3 PR develop → main
+
+PR 본문은 변경 요약 + 테스트 플랜 형식.
+
+```bash
+gh pr create --base main --head develop --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <1-3 bullet>
+
+## Changes
+- <file/area> — <what>
+
+## Test plan
+- [ ] xcodebuild GotoCLI / Goto 빌드 통과 확인
+- [ ] `~/.local/bin/goto` 인터랙티브 동작 확인
+- [ ] 회귀 점검: 핀/필터/정렬
+
+EOF
+)"
+```
+
+- PR URL 을 사용자에게 출력
+- **머지는 사용자가 직접 수행한다** — 스킬은 머지하지 않음
+- 머지 후 CI `release.yml` 이 자동으로 패치 버전 릴리즈 생성
+
+### 4-4 후속 안내
+
+```
+다음 단계:
+1. PR 리뷰 후 main 머지
+2. GitHub Actions release.yml 진행 상태 확인
+3. `gh release view --web` 로 릴리즈 확인
+```
+
+## 금지 사항
+
+- 사용자 미확인 상태 파일 삭제
+- `git push --force`, `git reset --hard` (사용자가 명시 요청한 경우 제외)
+- `main` 직접 푸시
+- `--no-verify`, `--no-gpg-sign` 같은 훅/서명 우회
+- `.env`, 키, 자격증명 파일 커밋
+- PR 자동 머지
+
+## 부분 실행
+
+사용자가 특정 단계만 원하면 그 단계만 수행한다:
+- `/ship-goto cleanup` → Stage 1 만
+- `/ship-goto docs` → Stage 2 만
+- `/ship-goto build` → Stage 3 만
+- `/ship-goto release` → Stage 4 만

--- a/GotoCLI/main.swift
+++ b/GotoCLI/main.swift
@@ -26,7 +26,11 @@ private func restoreMode(_ original: inout termios) {
 }
 
 private enum Key {
-    case up, down, left, right, enter, space, pin, esc, quit, other
+    case up, down, left, right, enter, space, pin, filter, esc, quit, other
+}
+
+private enum FilterEvent {
+    case up, down, enter, escape, backspace, append(UInt8), quit
 }
 
 private func readPendingByte() -> UInt8? {
@@ -55,6 +59,8 @@ private func readKey() -> Key {
         return .space
     case UInt8(ascii: "p"), UInt8(ascii: "P"):
         return .pin
+    case UInt8(ascii: "f"), UInt8(ascii: "F"):
+        return .filter
     case UInt8(ascii: "q"), UInt8(ascii: "Q"):
         return .quit
     case 3:
@@ -76,6 +82,82 @@ private func readKey() -> Key {
     }
 }
 
+private func readFilterEvent() -> FilterEvent {
+    var byte: UInt8 = 0
+    guard read(STDIN_FILENO, &byte, 1) == 1 else { return .escape }
+    switch byte {
+    case 0x1B:
+        guard let next = readPendingByte() else { return .escape }
+        guard next == UInt8(ascii: "[") else { return .escape }
+        guard let dir = readPendingByte() else { return .escape }
+        switch dir {
+        case UInt8(ascii: "A"): return .up
+        case UInt8(ascii: "B"): return .down
+        default: return .escape
+        }
+    case 0x0A, 0x0D:
+        return .enter
+    case 0x7F, 0x08:
+        return .backspace
+    case 3:
+        return .quit
+    default:
+        if byte >= 0x20 { return .append(byte) }
+        return .escape
+    }
+}
+
+private func hashSeed(_ text: String) -> UInt64 {
+    var hash: UInt64 = 0xcbf29ce484222325
+    for byte in text.utf8 {
+        hash ^= UInt64(byte)
+        hash = hash &* 0x100000001b3
+    }
+    return hash
+}
+
+private func hslToRgb(h: Double, s: Double, l: Double) -> (Int, Int, Int) {
+    let c = (1 - abs(2 * l - 1)) * s
+    let hp = h / 60.0
+    let x = c * (1 - abs(hp.truncatingRemainder(dividingBy: 2.0) - 1))
+    let r1: Double, g1: Double, b1: Double
+    switch Int(hp.rounded(.down)) {
+    case 0: (r1, g1, b1) = (c, x, 0)
+    case 1: (r1, g1, b1) = (x, c, 0)
+    case 2: (r1, g1, b1) = (0, c, x)
+    case 3: (r1, g1, b1) = (0, x, c)
+    case 4: (r1, g1, b1) = (x, 0, c)
+    default: (r1, g1, b1) = (c, 0, x)
+    }
+    let m = l - c / 2.0
+    let clamp: (Double) -> Int = { v in min(255, max(0, Int(((v + m) * 255).rounded()))) }
+    return (clamp(r1), clamp(g1), clamp(b1))
+}
+
+private func parentBgRgb(for parent: String) -> (Int, Int, Int) {
+    let h = hashSeed(parent)
+    let hue = Double(h % 360)
+    let satTable: [Double] = [0.50, 0.62, 0.74]
+    let lightTable: [Double] = [0.26, 0.32, 0.38, 0.44]
+    let sat = satTable[Int((h >> 16) % UInt64(satTable.count))]
+    let light = lightTable[Int((h >> 24) % UInt64(lightTable.count))]
+    return hslToRgb(h: hue, s: sat, l: light)
+}
+
+private func parentBadge(_ parent: String, width: Int, colored: Bool) -> String {
+    let padding = String(repeating: " ", count: max(0, width - parent.count))
+    if parent.isEmpty {
+        return String(repeating: " ", count: width + 2)
+    }
+    if !colored {
+        return " \(parent)\(padding) "
+    }
+    let (r, g, b) = parentBgRgb(for: parent)
+    let bg = "\u{1B}[48;2;\(r);\(g);\(b)m"
+    let fg = "\u{1B}[97m"
+    return "\(bg)\(fg) \(parent)\(padding) \u{1B}[49m\u{1B}[39m"
+}
+
 private enum MainRow {
     case project(String)
     case separator
@@ -94,6 +176,8 @@ private enum SettingsRow: CaseIterable {
     case pinSort
     case prefixSort
     case projectSort
+    case prefixColor
+    case prefixPattern
     case projectManagement
 }
 
@@ -123,8 +207,11 @@ private struct ProjectColumns {
     let nameWidth: Int
 }
 
-private func projectColumns(for paths: [String]) -> ProjectColumns {
-    let displayItems = paths.map { GotoProjectList.displayItem(for: $0) }
+private func projectColumns(
+    for paths: [String],
+    displayItem: (String) -> GotoProjectDisplayItem
+) -> ProjectColumns {
+    let displayItems = paths.map(displayItem)
     return ProjectColumns(
         parentWidth: displayItems.map(\.parent.count).max() ?? 0,
         nameWidth: displayItems.map(\.name.count).max() ?? 0
@@ -135,15 +222,32 @@ private func drawMainList(
     rows: [MainRow],
     pinnedSet: Set<String>,
     selected: Int,
+    filterQuery: String?,
+    displayItem: (String) -> GotoProjectDisplayItem,
+    colored: Bool,
     tty: UnsafeMutablePointer<FILE>
 ) {
     fputs(ansiClear, tty)
-    fputs("goto — 프로젝트 선택 (↑↓ 이동, Enter 선택, p 핀 토글, ESC/q 취소)\n\n", tty)
+    if let query = filterQuery {
+        fputs(
+            "goto — 필터: \(ansiBold)\(query)\(ansiBoldOff)\(ansiGray)▌\(ansiReset)  (↑↓ 이동, Enter 선택, ESC 필터 해제)\n\n",
+            tty
+        )
+    } else {
+        fputs(
+            "goto — 프로젝트 선택 (↑↓ 이동, Enter 선택, p 핀 토글, f 필터, ESC/q 취소)\n\n",
+            tty
+        )
+    }
     let projectPaths = rows.compactMap { row -> String? in
         if case .project(let path) = row { return path }
         return nil
     }
-    let columns = projectColumns(for: projectPaths)
+    let columns = projectColumns(for: projectPaths, displayItem: displayItem)
+
+    if filterQuery != nil && projectPaths.isEmpty {
+        fputs("  \(ansiGray)일치하는 프로젝트가 없습니다.\(ansiReset)\n", tty)
+    }
 
     for (i, row) in rows.enumerated() {
         switch row {
@@ -152,12 +256,13 @@ private func drawMainList(
         case .project(let path):
             fputs(
                 displayLine(
-                    item: GotoProjectList.displayItem(for: path),
+                    item: displayItem(path),
                     path: path,
                     parentWidth: columns.parentWidth,
                     nameWidth: columns.nameWidth,
                     isPinned: pinnedSet.contains(path),
-                    isSelected: i == selected
+                    isSelected: i == selected,
+                    colored: colored
                 ),
                 tty
             )
@@ -190,12 +295,13 @@ private func displayLine(
     parentWidth: Int,
     nameWidth: Int,
     isPinned: Bool,
-    isSelected: Bool
+    isSelected: Bool,
+    colored: Bool
 ) -> String {
-    let parent = padded(item.parent, to: parentWidth)
+    let badge = parentBadge(item.parent, width: parentWidth, colored: colored)
     let name = padded(item.name, to: nameWidth)
     let marker = isPinned ? "📌 " : "   "
-    let text = "\(marker)\(parent)  \(ansiBold)\(name)\(ansiBoldOff)  \(ansiGray)\(GotoProjectList.displayPath(for: path))"
+    let text = "\(marker)\(badge)  \(ansiBold)\(name)\(ansiBoldOff)  \(ansiGray)\(GotoProjectList.displayPath(for: path))"
     if isSelected {
         return "\(ansiInvertOn)  \(text)  \(ansiReset)\n"
     }
@@ -227,8 +333,17 @@ private func settingsOptionLine(
     optionLine(padded(title, to: titleWidth), value: value, isSelected: isSelected)
 }
 
-private func mainRows(projects: [String], config: GotoCLIConfig) -> [MainRow] {
-    let ordered = GotoProjectList.orderedProjects(projects, config: config)
+private func mainRows(
+    projects: [String],
+    config: GotoCLIConfig,
+    displayItem: @escaping (String) -> GotoProjectDisplayItem
+) -> [MainRow] {
+    let ordered = GotoProjectList.orderedProjects(
+        projects,
+        config: config,
+        parentNameProvider: { displayItem($0).parent },
+        projectNameProvider: { displayItem($0).name }
+    )
     var rows: [MainRow] = []
 
     let pinEnd = ordered.pinnedCount
@@ -291,7 +406,7 @@ private func drawSettings(config: GotoCLIConfig, selected: Int, tty: UnsafeMutab
     fputs(ansiClear, tty)
     fputs("goto — settings (↑↓ 이동, Enter/Space 변경, ESC 뒤로)\n\n", tty)
     let rows = SettingsRow.allCases
-    let titleWidth = "상위 폴더 정렬".count
+    let titleWidth = "prefix 패턴 매칭".count
     for (index, row) in rows.enumerated() {
         let isSelected = index == selected
         switch row {
@@ -306,6 +421,11 @@ private func drawSettings(config: GotoCLIConfig, selected: Int, tty: UnsafeMutab
         case .projectSort:
             let option = GotoSettings.sortOption(field: config.projectSortField, direction: config.projectSortDirection)
             fputs(settingsOptionLine("프로젝트 정렬", value: option.title, titleWidth: titleWidth, isSelected: isSelected), tty)
+            fputs("\n\(separatorLine(for: tty))\n\n", tty)
+        case .prefixColor:
+            fputs(settingsOptionLine("prefix 색상", value: config.prefixColorEnabled ? "켜짐" : "꺼짐", titleWidth: titleWidth, isSelected: isSelected), tty)
+        case .prefixPattern:
+            fputs(settingsOptionLine("prefix 패턴 매칭", value: config.prefixPatternEnabled ? "켜짐" : "꺼짐", titleWidth: titleWidth, isSelected: isSelected), tty)
             fputs("\n\(separatorLine(for: tty))\n\n", tty)
         case .projectManagement:
             fputs(menuLine("프로젝트 관리", isSelected: isSelected), tty)
@@ -353,10 +473,16 @@ private func runSettings(config: inout GotoCLIConfig, tty: UnsafeMutablePointer<
                 config.projectSortField = next.field
                 config.projectSortDirection = next.direction
                 GotoSettings.saveCLIConfig(config)
+            case .prefixColor:
+                config.prefixColorEnabled.toggle()
+                GotoSettings.saveCLIConfig(config)
+            case .prefixPattern:
+                config.prefixPatternEnabled.toggle()
+                GotoSettings.saveCLIConfig(config)
             case .projectManagement:
                 return .openProjectManagement
             }
-        case .pin:
+        case .pin, .filter:
             break
         case .esc:
             return .back
@@ -369,8 +495,18 @@ private func runSettings(config: inout GotoCLIConfig, tty: UnsafeMutablePointer<
     }
 }
 
-private func projectManagementRows(projects: [String], config: GotoCLIConfig) -> [ProjectManagementRow] {
-    let projectRows = GotoProjectList.sortedProjects(projects, config: config).map { ProjectManagementRow.project($0) }
+private func projectManagementRows(
+    projects: [String],
+    config: GotoCLIConfig,
+    displayItem: @escaping (String) -> GotoProjectDisplayItem
+) -> [ProjectManagementRow] {
+    let sorted = GotoProjectList.sortedProjects(
+        projects,
+        config: config,
+        parentNameProvider: { displayItem($0).parent },
+        projectNameProvider: { displayItem($0).name }
+    )
+    let projectRows = sorted.map { ProjectManagementRow.project($0) }
     return [.back] + projectRows + [.separator, .removeSelected]
 }
 
@@ -379,6 +515,8 @@ private func drawProjectManagement(
     marked: Set<String>,
     pinnedSet: Set<String>,
     selected: Int,
+    displayItem: (String) -> GotoProjectDisplayItem,
+    colored: Bool,
     tty: UnsafeMutablePointer<FILE>
 ) {
     fputs(ansiClear, tty)
@@ -388,7 +526,7 @@ private func drawProjectManagement(
         if case .project(let path) = row { return path }
         return nil
     }
-    let columns = projectColumns(for: projectPaths)
+    let columns = projectColumns(for: projectPaths, displayItem: displayItem)
 
     for (index, row) in rows.enumerated() {
         let isSelected = index == selected
@@ -403,10 +541,10 @@ private func drawProjectManagement(
         case .project(let path):
             let mark = marked.contains(path) ? "[x]" : "[ ]"
             let pin = pinnedSet.contains(path) ? "📌" : "  "
-            let item = GotoProjectList.displayItem(for: path)
-            let parent = padded(item.parent, to: columns.parentWidth)
+            let item = displayItem(path)
+            let badge = parentBadge(item.parent, width: columns.parentWidth, colored: colored)
             let name = padded(item.name, to: columns.nameWidth)
-            let text = "\(mark) \(pin) \(parent)  \(ansiBold)\(name)\(ansiBoldOff)  \(ansiGray)\(GotoProjectList.displayPath(for: path))"
+            let text = "\(mark) \(pin) \(badge)  \(ansiBold)\(name)\(ansiBoldOff)  \(ansiGray)\(GotoProjectList.displayPath(for: path))"
             if isSelected {
                 fputs("\(ansiInvertOn)  \(text)  \(ansiReset)\n", tty)
             } else {
@@ -421,11 +559,22 @@ private func runProjectManagement(
     config: GotoCLIConfig,
     tty: UnsafeMutablePointer<FILE>
 ) {
-    var rows = projectManagementRows(projects: projects, config: config)
+    func makeDisplayItem() -> (String) -> GotoProjectDisplayItem {
+        let set = config.prefixPatternEnabled ? GotoProjectList.patternPrefixSet(in: projects) : []
+        let enabled = config.prefixPatternEnabled
+        return { path in
+            GotoProjectList.cliDisplayItem(for: path, sharedPrefixes: set, patternEnabled: enabled)
+        }
+    }
+    var displayItem = makeDisplayItem()
+    let colored = config.prefixColorEnabled
+
+    var rows = projectManagementRows(projects: projects, config: config, displayItem: displayItem)
     var selected = firstSelectableIndex(in: rows) { $0.isSelectable }
     var marked = Set<String>()
     var pinnedSet = Set(GotoProjectList.loadPinnedProjects(availableProjects: projects))
-    drawProjectManagement(rows: rows, marked: marked, pinnedSet: pinnedSet, selected: selected, tty: tty)
+
+    drawProjectManagement(rows: rows, marked: marked, pinnedSet: pinnedSet, selected: selected, displayItem: displayItem, colored: colored, tty: tty)
 
     while true {
         switch readKey() {
@@ -452,7 +601,8 @@ private func runProjectManagement(
                     GotoProjectList.setPinned(path, pinned: false, availableProjects: GotoProjectStore.load())
                 }
                 projects = GotoProjectStore.load()
-                rows = projectManagementRows(projects: projects, config: config)
+                displayItem = makeDisplayItem()
+                rows = projectManagementRows(projects: projects, config: config, displayItem: displayItem)
                 marked.removeAll()
                 pinnedSet = Set(GotoProjectList.loadPinnedProjects(availableProjects: projects))
                 selected = lastSelectableIndex(in: rows) { $0.isSelectable }
@@ -467,10 +617,10 @@ private func runProjectManagement(
             }
         case .esc, .quit:
             return
-        case .other:
+        case .filter, .other:
             break
         }
-        drawProjectManagement(rows: rows, marked: marked, pinnedSet: pinnedSet, selected: selected, tty: tty)
+        drawProjectManagement(rows: rows, marked: marked, pinnedSet: pinnedSet, selected: selected, displayItem: displayItem, colored: colored, tty: tty)
     }
 }
 
@@ -489,12 +639,85 @@ private func runInteractive(projects initialProjects: [String]) -> InteractiveRe
 
     var projects = initialProjects
     var config = GotoSettings.cliConfig()
-    var rows = mainRows(projects: projects, config: config)
     var pinnedSet = Set(GotoProjectList.loadPinnedProjects(availableProjects: projects))
+    var filterQuery: String? = nil
+
+    func makeDisplayItem() -> (String) -> GotoProjectDisplayItem {
+        let set = config.prefixPatternEnabled ? GotoProjectList.patternPrefixSet(in: projects) : []
+        let enabled = config.prefixPatternEnabled
+        return { path in
+            GotoProjectList.cliDisplayItem(for: path, sharedPrefixes: set, patternEnabled: enabled)
+        }
+    }
+    var displayItem = makeDisplayItem()
+
+    func makeRows() -> [MainRow] {
+        if let q = filterQuery {
+            let needle = q.lowercased()
+            let sorted = GotoProjectList.sortedProjects(
+                projects,
+                config: config,
+                parentNameProvider: { displayItem($0).parent },
+                projectNameProvider: { displayItem($0).name }
+            )
+            let filtered: [String]
+            if needle.isEmpty {
+                filtered = sorted
+            } else {
+                filtered = sorted.filter { path in
+                    let item = displayItem(path)
+                    return item.parent.lowercased().contains(needle)
+                        || item.name.lowercased().contains(needle)
+                        || path.lowercased().contains(needle)
+                }
+            }
+            return filtered.map { .project($0) }
+        }
+        return mainRows(projects: projects, config: config, displayItem: displayItem)
+    }
+
+    var rows = makeRows()
     var selected = firstSelectableIndex(in: rows) { $0.isSelectable }
-    drawMainList(rows: rows, pinnedSet: pinnedSet, selected: selected, tty: tty)
+    drawMainList(rows: rows, pinnedSet: pinnedSet, selected: selected, filterQuery: filterQuery, displayItem: displayItem, colored: config.prefixColorEnabled, tty: tty)
 
     while true {
+        if filterQuery != nil {
+            let evt = readFilterEvent()
+            switch evt {
+            case .append(let byte):
+                filterQuery = (filterQuery ?? "") + String(UnicodeScalar(byte))
+                rows = makeRows()
+                selected = firstSelectableIndex(in: rows) { $0.isSelectable }
+            case .backspace:
+                if var q = filterQuery, !q.isEmpty {
+                    q.removeLast()
+                    filterQuery = q
+                    rows = makeRows()
+                    selected = firstSelectableIndex(in: rows) { $0.isSelectable }
+                }
+            case .up:
+                selected = nextSelectableIndex(from: selected, delta: -1, rows: rows) { $0.isSelectable }
+            case .down:
+                selected = nextSelectableIndex(from: selected, delta: 1, rows: rows) { $0.isSelectable }
+            case .enter:
+                if !rows.isEmpty, rows.indices.contains(selected),
+                   case .project(let chosen) = rows[selected] {
+                    GotoProjectList.recordRecentProject(chosen, availableProjects: projects)
+                    fputs(ansiClear, tty)
+                    return .chosen(chosen)
+                }
+            case .escape:
+                filterQuery = nil
+                rows = makeRows()
+                selected = firstSelectableIndex(in: rows) { $0.isSelectable }
+            case .quit:
+                fputs(ansiClear, tty)
+                return .cancelled
+            }
+            drawMainList(rows: rows, pinnedSet: pinnedSet, selected: selected, filterQuery: filterQuery, displayItem: displayItem, colored: config.prefixColorEnabled, tty: tty)
+            continue
+        }
+
         let key = readKey()
         switch key {
         case .up:
@@ -505,10 +728,14 @@ private func runInteractive(projects initialProjects: [String]) -> InteractiveRe
             selected = firstSelectableIndex(in: rows) { $0.isSelectable }
         case .right:
             selected = lastSelectableIndex(in: rows) { $0.isSelectable }
+        case .filter:
+            filterQuery = ""
+            rows = makeRows()
+            selected = firstSelectableIndex(in: rows) { $0.isSelectable }
         case .pin:
             if case .project(let path) = rows[selected] {
                 GotoProjectList.togglePinned(path, availableProjects: projects)
-                rows = mainRows(projects: projects, config: config)
+                rows = makeRows()
                 pinnedSet = Set(GotoProjectList.loadPinnedProjects(availableProjects: projects))
                 if let idx = rows.firstIndex(where: { row in
                     if case .project(let p) = row { return p == path }
@@ -536,7 +763,8 @@ private func runInteractive(projects initialProjects: [String]) -> InteractiveRe
                     return .cancelled
                 }
                 config = GotoSettings.cliConfig()
-                rows = mainRows(projects: projects, config: config)
+                displayItem = makeDisplayItem()
+                rows = makeRows()
                 pinnedSet = Set(GotoProjectList.loadPinnedProjects(availableProjects: projects))
                 selected = firstSelectableIndex(in: rows) { $0.isSelectable }
             case .separator:
@@ -548,7 +776,7 @@ private func runInteractive(projects initialProjects: [String]) -> InteractiveRe
         case .other:
             break
         }
-        drawMainList(rows: rows, pinnedSet: pinnedSet, selected: selected, tty: tty)
+        drawMainList(rows: rows, pinnedSet: pinnedSet, selected: selected, filterQuery: filterQuery, displayItem: displayItem, colored: config.prefixColorEnabled, tty: tty)
     }
 }
 

--- a/Shared/GotoCLISettings.swift
+++ b/Shared/GotoCLISettings.swift
@@ -16,11 +16,14 @@ struct GotoCLIConfig: Codable {
     var projectSortField: GotoProjectSortField = .name
     var projectSortDirection: GotoSortDirection = .descending
     var pinSortMode: GotoPinSortMode = .insertion
+    var prefixColorEnabled: Bool = true
+    var prefixPatternEnabled: Bool = true
 
     enum CodingKeys: String, CodingKey {
         case parentSortField, parentSortDirection
         case projectSortField, projectSortDirection
         case pinSortMode
+        case prefixColorEnabled, prefixPatternEnabled
     }
 
     init(
@@ -28,13 +31,17 @@ struct GotoCLIConfig: Codable {
         parentSortDirection: GotoSortDirection = .descending,
         projectSortField: GotoProjectSortField = .name,
         projectSortDirection: GotoSortDirection = .descending,
-        pinSortMode: GotoPinSortMode = .insertion
+        pinSortMode: GotoPinSortMode = .insertion,
+        prefixColorEnabled: Bool = true,
+        prefixPatternEnabled: Bool = true
     ) {
         self.parentSortField = parentSortField
         self.parentSortDirection = parentSortDirection
         self.projectSortField = projectSortField
         self.projectSortDirection = projectSortDirection
         self.pinSortMode = pinSortMode
+        self.prefixColorEnabled = prefixColorEnabled
+        self.prefixPatternEnabled = prefixPatternEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -44,6 +51,8 @@ struct GotoCLIConfig: Codable {
         projectSortField = try c.decodeIfPresent(GotoProjectSortField.self, forKey: .projectSortField) ?? .name
         projectSortDirection = try c.decodeIfPresent(GotoSortDirection.self, forKey: .projectSortDirection) ?? .descending
         pinSortMode = try c.decodeIfPresent(GotoPinSortMode.self, forKey: .pinSortMode) ?? .insertion
+        prefixColorEnabled = try c.decodeIfPresent(Bool.self, forKey: .prefixColorEnabled) ?? true
+        prefixPatternEnabled = try c.decodeIfPresent(Bool.self, forKey: .prefixPatternEnabled) ?? true
     }
 }
 
@@ -158,6 +167,46 @@ enum GotoProjectList {
         )
     }
 
+    static func namePatternPrefix(for name: String) -> (prefix: String, rest: String)? {
+        guard let dashIdx = name.firstIndex(of: "-") else { return nil }
+        let prefix = String(name[..<dashIdx])
+        let rest = String(name[name.index(after: dashIdx)...])
+        guard !prefix.isEmpty, !rest.isEmpty else { return nil }
+        return (prefix, rest)
+    }
+
+    static func patternPrefixSet(in projects: [String]) -> Set<String> {
+        var counts: [String: Int] = [:]
+        for path in projects {
+            let name = URL(fileURLWithPath: path).lastPathComponent
+            if let parsed = namePatternPrefix(for: name) {
+                counts[parsed.prefix, default: 0] += 1
+            }
+        }
+        return Set(counts.filter { $0.value >= 2 }.keys)
+    }
+
+    static func cliDisplayItem(
+        for path: String,
+        sharedPrefixes: Set<String>,
+        patternEnabled: Bool
+    ) -> GotoProjectDisplayItem {
+        let url = URL(fileURLWithPath: path)
+        let name = url.lastPathComponent
+        guard !name.isEmpty else {
+            return GotoProjectDisplayItem(parent: "", name: path)
+        }
+        if patternEnabled,
+           let parsed = namePatternPrefix(for: name),
+           sharedPrefixes.contains(parsed.prefix) {
+            return GotoProjectDisplayItem(parent: parsed.prefix, name: parsed.rest)
+        }
+        return GotoProjectDisplayItem(
+            parent: url.deletingLastPathComponent().lastPathComponent,
+            name: name
+        )
+    }
+
     static func displayPath(for path: String) -> String {
         let homePath = FileManager.default.homeDirectoryForCurrentUser.path
         if path == homePath {
@@ -256,7 +305,22 @@ enum GotoProjectList {
     }
 
     static func sortedProjects(_ projects: [String], config: GotoCLIConfig) -> [String] {
-        projects.sorted { compareProjects($0, $1, config: config) }
+        projects.sorted { compareProjects($0, $1, config: config, parentNameProvider: nil, projectNameProvider: nil) }
+    }
+
+    static func sortedProjects(
+        _ projects: [String],
+        config: GotoCLIConfig,
+        parentNameProvider: @escaping (String) -> String,
+        projectNameProvider: @escaping (String) -> String
+    ) -> [String] {
+        projects.sorted {
+            compareProjects(
+                $0, $1, config: config,
+                parentNameProvider: parentNameProvider,
+                projectNameProvider: projectNameProvider
+            )
+        }
     }
 
     static func sortedPinned(_ pins: [String], mode: GotoPinSortMode) -> [String] {
@@ -297,6 +361,15 @@ enum GotoProjectList {
         _ projects: [String],
         config: GotoCLIConfig
     ) -> (displayProjects: [String], pinnedCount: Int, recentCount: Int) {
+        return orderedProjects(projects, config: config, parentNameProvider: nil, projectNameProvider: nil)
+    }
+
+    static func orderedProjects(
+        _ projects: [String],
+        config: GotoCLIConfig,
+        parentNameProvider: ((String) -> String)?,
+        projectNameProvider: ((String) -> String)?
+    ) -> (displayProjects: [String], pinnedCount: Int, recentCount: Int) {
         let pins = sortedPinned(
             loadPinnedProjects(availableProjects: projects),
             mode: config.pinSortMode
@@ -307,17 +380,29 @@ enum GotoProjectList {
         let recentSet = Set(recents)
         let remaining = projects
             .filter { !pinSet.contains($0) && !recentSet.contains($0) }
-            .sorted { compareProjects($0, $1, config: config) }
+            .sorted {
+                compareProjects(
+                    $0, $1, config: config,
+                    parentNameProvider: parentNameProvider,
+                    projectNameProvider: projectNameProvider
+                )
+            }
         return (pins + recents + remaining, pins.count, recents.count)
     }
 
-    private static func compareProjects(_ lhs: String, _ rhs: String, config: GotoCLIConfig) -> Bool {
-        let parent = parentComparison(lhs, rhs, config: config)
+    private static func compareProjects(
+        _ lhs: String,
+        _ rhs: String,
+        config: GotoCLIConfig,
+        parentNameProvider: ((String) -> String)?,
+        projectNameProvider: ((String) -> String)?
+    ) -> Bool {
+        let parent = parentComparison(lhs, rhs, config: config, parentNameProvider: parentNameProvider)
         if parent != .orderedSame {
             return parent == .orderedAscending
         }
 
-        let project = projectComparison(lhs, rhs, config: config)
+        let project = projectComparison(lhs, rhs, config: config, projectNameProvider: projectNameProvider)
         if project != .orderedSame {
             return project == .orderedAscending
         }
@@ -325,14 +410,17 @@ enum GotoProjectList {
         return lhs.localizedStandardCompare(rhs) == .orderedAscending
     }
 
-    private static func parentComparison(_ lhs: String, _ rhs: String, config: GotoCLIConfig) -> ComparisonResult {
+    private static func parentComparison(
+        _ lhs: String,
+        _ rhs: String,
+        config: GotoCLIConfig,
+        parentNameProvider: ((String) -> String)?
+    ) -> ComparisonResult {
         switch config.parentSortField {
         case .name:
-            return compareStrings(
-                displayItem(for: lhs).parent,
-                displayItem(for: rhs).parent,
-                direction: config.parentSortDirection
-            )
+            let leftName = parentNameProvider?(lhs) ?? displayItem(for: lhs).parent
+            let rightName = parentNameProvider?(rhs) ?? displayItem(for: rhs).parent
+            return compareStrings(leftName, rightName, direction: config.parentSortDirection)
         case .createdAt:
             return compareDates(
                 creationDate(for: parentPath(for: lhs)),
@@ -342,14 +430,17 @@ enum GotoProjectList {
         }
     }
 
-    private static func projectComparison(_ lhs: String, _ rhs: String, config: GotoCLIConfig) -> ComparisonResult {
+    private static func projectComparison(
+        _ lhs: String,
+        _ rhs: String,
+        config: GotoCLIConfig,
+        projectNameProvider: ((String) -> String)?
+    ) -> ComparisonResult {
         switch config.projectSortField {
         case .name:
-            return compareStrings(
-                displayItem(for: lhs).name,
-                displayItem(for: rhs).name,
-                direction: config.projectSortDirection
-            )
+            let leftName = projectNameProvider?(lhs) ?? displayItem(for: lhs).name
+            let rightName = projectNameProvider?(rhs) ?? displayItem(for: rhs).name
+            return compareStrings(leftName, rightName, direction: config.projectSortDirection)
         case .createdAt:
             return compareDates(creationDate(for: lhs), creationDate(for: rhs), direction: config.projectSortDirection)
         }

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -5,6 +5,7 @@
 - [[summaries/cleanup-2026-05-06]] — cleanup pass for shared project list logic, root artifacts, and documentation.
 - [[summaries/icon-glyph-fix-2026-05-11]] — fix menu bar & Finder Sync white square caused by `ctx.clear` on PDF context.
 - [[summaries/settings-window-front-2026-05-11]] — settings window front-most fix when triggered from the menu bar on macOS 14+.
+- [[summaries/cli-prefix-features-2026-05-13]] — CLI prefix true-color badge, `f` filter mode, and shared `xxx-` pattern prefix with two new config toggles.
 
 ## Concepts
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,9 @@
 # Goto Wiki Log
 
+## 2026-05-13 feat | CLI prefix color, f filter, pattern prefix
+
+CLI 인터랙티브 모드에 prefix true-color 배경 배지(FNV-1a 64-bit → HSL with sat/light variants), `f` 키 필터(Claude Code 스타일), 동일 prefix 가 2개 이상 등록됐을 때만 적용되는 `xxx-` 패턴 prefix 매칭을 추가했다. 설정에 `prefixColorEnabled`, `prefixPatternEnabled` 두 토글을 노출해 영속 저장한다. 패턴 prefix 활성화 시 정렬 키도 패턴 prefix 로 통일되어 동일 prefix 항목이 인접 배치된다. 메뉴바 앱 동작은 변하지 않는다. See `summaries/cli-prefix-features-2026-05-13`.
+
 ## 2026-05-06 init | project wiki
 
 Initialized the llm-wiki structure for durable Goto project knowledge.

--- a/wiki/summaries/cli-prefix-features-2026-05-13.md
+++ b/wiki/summaries/cli-prefix-features-2026-05-13.md
@@ -1,0 +1,57 @@
+---
+tags: [cli, settings]
+date: 2026-05-13
+---
+
+# CLI Prefix Color + `f` Filter + Pattern Prefix
+
+CLI 인터랙티브 모드에 prefix 표현·검색 기능을 강화했다.
+
+## 변경 요약
+
+### 1. Prefix 배경색 (true color)
+
+- 상위 폴더 또는 패턴 prefix 문자열을 **FNV-1a 64-bit 해시 → HSL 색공간** 으로 매핑해 배경 배지로 렌더링한다.
+- hue 0~359 외에 채도 3 단계(0.50 / 0.62 / 0.74) · 명도 4 단계(0.26 / 0.32 / 0.38 / 0.44) 를 해시 상위 비트로 변주해 2160 톤 변형 공간을 확보. 인접 hue 충돌을 시각적으로 분리한다.
+- 동일 prefix 는 항상 동일 색, 빈 prefix(최상위 경로) 는 색상 없음.
+- 메인 리스트와 프로젝트 관리 화면 양쪽에 적용.
+
+### 2. `f` 필터 모드
+
+- 메인 리스트에서 `f` 또는 `F` 키로 진입. Claude Code 의 status 필터와 유사한 UX.
+- 헤더가 `goto — 필터: <query>▌` 로 전환되고 입력 즉시 실시간 필터링.
+- 매치 기준: `displayItem.parent`, `displayItem.name`, 전체 경로 모두 case-insensitive substring.
+- 키:
+  - 인쇄 가능 ASCII → 쿼리 누적
+  - Backspace(0x7F/0x08) → 마지막 글자 제거
+  - ↑↓ → 결과 내 이동
+  - Enter → 선택
+  - ESC → 쿼리 해제, 일반 모드 복귀
+  - Ctrl-C → 종료
+- 결과 0건이면 안내 문구 표시. 필터 중에는 separator/settings 행을 숨겨 플랫 결과 리스트만 노출.
+
+### 3. `xxx-` 패턴 prefix
+
+- 프로젝트 폴더명이 `xxx-yyy...` 형태이고, 동일 `xxx` 가 등록된 프로젝트 **2개 이상**에 등장할 때만 `xxx` 를 prefix 로 사용한다.
+- 조건 미충족(단일 등장 또는 패턴 없음)이면 기존 동작인 상위 폴더명을 prefix 로 fallback.
+- 첫 `-` 기준 분리. `oa-platform/oa-backend` 같은 중첩에서도 폴더명 자체가 `oa-backend` 이므로 `oa` 가 추출되어 다른 `oa-*` 와 묶인다.
+- 표시·필터·**정렬** 모두 동일 prefix 기준으로 동작 → 동일 prefix 항목은 인접 배치.
+
+### 4. 설정 2개 추가 (`~/.goto_config` 영속)
+
+- `prefixColorEnabled` (기본 `true`) — 배경색 ON/OFF
+- `prefixPatternEnabled` (기본 `true`) — 패턴 prefix 매칭 ON/OFF
+- CLI Settings 화면에서 Enter/Space 로 토글. `prefix 색상`, `prefix 패턴 매칭` 행.
+- 메뉴바 앱은 영향 없음. `displayItem(for:)` 본체는 그대로 유지하고 CLI 전용 `cliDisplayItem(for:sharedPrefixes:patternEnabled:)` 신규 함수를 사용.
+
+## 구현 노트
+
+- `Shared/GotoCLISettings.swift`
+  - `GotoProjectList.namePatternPrefix(for:)`, `patternPrefixSet(in:)`, `cliDisplayItem(...)` 추가
+  - `orderedProjects` / `sortedProjects` 에 `parentNameProvider` / `projectNameProvider` 클로저 오버로드 추가. 기존 호출(메뉴바) 무영향
+  - `GotoCLIConfig` 에 `prefixColorEnabled`, `prefixPatternEnabled` 코딩키·디코더 추가
+- `GotoCLI/main.swift`
+  - `Key.filter`, `FilterEvent`, `readFilterEvent()` 추가
+  - `hashSeed`(FNV-1a), `hslToRgb`, `parentBgRgb`, `parentBadge(_:width:colored:)`
+  - `mainRows`/`projectManagementRows`/`drawMainList`/`drawProjectManagement` 가 `displayItem` 클로저와 `colored` 플래그 수신
+  - `SettingsRow.prefixColor`, `.prefixPattern` 케이스 추가


### PR DESCRIPTION
## Summary
- CLI prefix true-color badge (FNV-1a → HSL with sat/light variants).
- `f` key live filter mode (Claude Code style); matches parent/name/path.
- Pattern prefix `xxx-yyy` applies when `xxx` appears in ≥2 registered projects; affects display, filter, and sort. Falls back to parent folder otherwise.
- Two new CLI Settings toggles persisted in `~/.goto_config`:
  - `prefix 색상` (prefixColorEnabled)
  - `prefix 패턴 매칭` (prefixPatternEnabled)
- Menu bar app behavior unchanged (CLI-only helpers added alongside shared API).
- Project-local skill `.claude/skills/ship-goto/` added to drive the cleanup → docs → build/install → commit/push/PR pipeline.

## Changes
- `GotoCLI/main.swift` — Key.filter, FilterEvent, parentBadge (true-color), pattern-aware display/sort, settings rows.
- `Shared/GotoCLISettings.swift` — `namePatternPrefix`, `patternPrefixSet`, `cliDisplayItem`, sort overloads with name providers, two config fields.
- `wiki/` — summary `cli-prefix-features-2026-05-13`, log/index updated.
- `.claude/skills/ship-goto/SKILL.md` — local release skill.

## Test plan
- [ ] `xcodebuild -scheme GotoCLI -configuration Release` succeeds.
- [ ] `xcodebuild -scheme Goto -configuration Debug` succeeds (no shared regression).
- [ ] `goto` interactive: prefix badges distinct across `inchan`, `experimental`, `oa`, `officeagent`.
- [ ] `f` enters filter; typing narrows, Backspace removes, ↑↓ navigates, Enter selects, ESC clears.
- [ ] Pattern prefix groups `oa-backoffice` adjacent to other `oa-*` regardless of parent dir.
- [ ] Toggling either setting off restores legacy parent-folder display / plain background.
- [ ] Menu bar app unchanged.