### PR TITLE
feat(installer): package apps and cli together

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,13 +89,23 @@ jobs:
           xcodebuild "${common[@]}" -scheme GotoLauncher build
           xcodebuild "${common[@]}" -scheme GotoCLI build
 
-      - name: Stage DMG contents
+      - name: Build installer package
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
-          rm -rf dist
+          ./scripts/build-installer.sh "$NEXT"
+
+      - name: Stage DMG contents
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          rm -rf dist/dmg
           mkdir -p dist/dmg
-          cp -R "./build/Build/Products/Release/Goto.app" "./dist/dmg/Goto.app"
-          cp -R "./build/Build/Products/Release/GotoLauncher.app" "./dist/dmg/Goto Launcher.app"
+          cp "./dist/Goto-$NEXT.pkg" "./dist/dmg/Install Goto.pkg"
+          cp scripts/uninstall.sh "./dist/dmg/Uninstall Goto.command"
+          chmod +x "./dist/dmg/Uninstall Goto.command"
           cp README.md ./dist/dmg/README.md
 
       - name: Build DMG
@@ -103,27 +113,12 @@ jobs:
           NEXT: ${{ steps.ver.outputs.next }}
         run: |
           set -euo pipefail
+          rm -f "./dist/Goto-$NEXT.dmg"
           create-dmg \
+            --skip-jenkins \
             --volname "Goto $NEXT" \
-            --window-pos 200 120 \
-            --window-size 720 420 \
-            --icon-size 100 \
-            --icon "Goto.app" 175 180 \
-            --icon "Goto Launcher.app" 360 180 \
-            --app-drop-link 545 180 \
             "./dist/Goto-$NEXT.dmg" \
             ./dist/dmg/
-
-      - name: Stage CLI zip
-        env:
-          NEXT: ${{ steps.ver.outputs.next }}
-        run: |
-          set -euo pipefail
-          mkdir -p "./dist/goto-cli"
-          cp "./build/Build/Products/Release/goto" "./dist/goto-cli/goto"
-          cp scripts/install-cli.sh "./dist/goto-cli/install-cli.sh"
-          chmod +x "./dist/goto-cli/install-cli.sh"
-          (cd ./dist && zip -r "goto-cli-$NEXT.zip" goto-cli/)
 
       - name: Create GitHub Release
         env:
@@ -136,5 +131,4 @@ jobs:
           gh release create "$NEXT" \
             --generate-notes \
             --title "$NEXT" \
-            "./dist/Goto-$NEXT.dmg" \
-            "./dist/goto-cli-$NEXT.zip"
+            "./dist/Goto-$NEXT.dmg"

--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@ Finder Sync Extension 기반 터미널 열기 앱입니다.
 
 ## 설치 (Release)
 
-GitHub Releases에 두 자산이 첨부됩니다.
+GitHub Releases에서 `Goto-vX.Y.Z.dmg`를 내려받습니다.
 
-- `Goto-vX.Y.Z.dmg` — `Goto.app` + `Goto Launcher.app` 인스톨러. 마운트 후 두 앱을 `Applications` 단축에 드래그합니다.
-- `goto-cli-vX.Y.Z.zip` — CLI binary + `install-cli.sh`. 압축을 풀고 `./install-cli.sh`를 실행하면 `~/.local/bin/goto`로 설치되고 셸 함수가 등록됩니다.
+DMG를 열고 `Install Goto.pkg`를 실행하면 다음 항목이 한 번에 설치됩니다.
+
+- `/Applications/Goto.app`
+- `/Applications/Goto Launcher.app`
+- `/usr/local/bin/goto`
+- `/usr/local/bin/goto-uninstall`
+- 현재 로그인 사용자의 셸 설정에 `goto()` wrapper 함수
 
 처음 실행 시 macOS Gatekeeper가 "확인되지 않은 개발자" 경고를 띄울 수 있습니다. 다음 둘 중 하나로 우회하세요.
 
 ```sh
-# 방법 1: Finder에서 Goto.app 우클릭 → 열기 (한 번만 승인하면 됩니다).
+# 방법 1: Finder에서 Install Goto.pkg 또는 Goto.app 우클릭 → 열기 (한 번만 승인하면 됩니다).
 # 방법 2: quarantine 속성 제거.
-xattr -dr com.apple.quarantine /Applications/Goto.app "/Applications/Goto Launcher.app"
+sudo xattr -dr com.apple.quarantine /Applications/Goto.app "/Applications/Goto Launcher.app" /usr/local/bin/goto
 ```
 
 ## 동작
@@ -52,18 +57,43 @@ goto --help                       # 도움말
 - 핀 고정한 프로젝트는 `~/.goto_pinned`에 저장되며 인터랙티브 리스트와 메뉴바의 **최상단**에 📌 마커와 함께 표시됩니다. 인터랙티브 리스트에서 `Ctrl+P`로 토글, 메뉴바에서는 ⌥ 키를 누른 채 항목 위에 마우스를 올리면 "핀 고정/해제" 항목이 alternate로 표시됩니다.
 - 최근 선택한 프로젝트는 `~/.goto_recent`에 저장되고, 핀 고정 영역 바로 아래에 표시됩니다(핀과 중복 시 핀 영역에서만 표시). 표시 개수는 기본 **5개**이며 CLI settings의 `최근 항목 개수`(Space: 0/1/3/5/10 순환, Enter: 직접 입력) 또는 macOS 앱 환경설정창의 `최근 개수` 콤보박스(선택 또는 직접 입력)에서 `0~50` 범위로 지정할 수 있습니다.
 - 정렬 설정은 `~/.goto_config`에 저장됩니다. CLI settings에서 핀 정렬, 상위 폴더 정렬, 프로젝트 정렬을 각각 변경할 수 있습니다. 핀 정렬 기본값은 "추가순"(insertion order).
-- 인터랙티브 선택은 **현재 셸에서 `cd`**합니다. 셸 함수 wrapper(install 스크립트가 `~/.zshrc`/`~/.bashrc`에 멱등 추가)가 binary stdout을 받아 `cd` 실행
+- 인터랙티브 선택은 **현재 셸에서 `cd`**합니다. 설치 과정이 셸 시작 파일에 추가한 `goto()` wrapper가 binary stdout을 받아 `cd` 실행
 - 비TTY(파이프) 호출 시 리스트를 stdout 한 줄씩 출력 (`goto | grep ...` 가능)
 
 ### 설치
+
+Release 설치는 `Install Goto.pkg`가 자동으로 처리합니다. 설치 직후 새 셸 세션을 열거나 다음 명령으로 함수를 즉시 적용하세요.
+
+```sh
+source ~/.zshrc       # zsh
+source ~/.bash_profile 2>/dev/null || source ~/.bashrc  # bash
+```
+
+로컬 개발 빌드에서 직접 설치하려면:
 
 ```sh
 ./install.sh
 ```
 
-xcodegen + xcodebuild로 binary 빌드 → `~/.local/bin/goto` 복사 → `~/.zshrc`/`~/.bashrc`에 셸 함수 추가.
+xcodegen + xcodebuild로 앱과 binary를 빌드하고 로컬에 설치합니다.
 
-설치 후 `source ~/.zshrc` 또는 새 셸 세션을 여세요.
+### 제거
+
+기본 제거는 앱, CLI binary, shell wrapper, installer receipt를 지우고 프로젝트 목록과 설정 데이터는 보존합니다.
+
+```sh
+sudo /usr/local/bin/goto-uninstall
+```
+
+DMG를 다시 열 수 있으면 `Uninstall Goto.command`를 실행해도 됩니다.
+
+사용자 데이터까지 모두 지우려면:
+
+```sh
+sudo /usr/local/bin/goto-uninstall --purge
+```
+
+`--purge`는 `~/.goto`, `~/.goto_recent`, `~/.goto_pinned`, `~/.goto_config`, Goto preferences, Finder Sync container data까지 제거합니다. 제거 스크립트는 예전 설치 방식의 `/Applications/GotoLauncher.app`, `Goto3` 앱 이름, `~/.local/bin/goto`, old shell marker도 함께 정리합니다.
 
 ## 메뉴바 (Settings 토글)
 
@@ -106,11 +136,17 @@ xcodegen generate
 xcodebuild -project Goto.xcodeproj -scheme Goto -configuration Debug build
 ```
 
-Release 앱 설치는 빌드 산출물의 `Goto.app`과 `GotoLauncher.app`을 `/Applications`로 복사해서 진행합니다. 프로젝트 루트에는 빌드 산출물 앱 번들을 보관하지 않습니다.
+Release 앱 설치는 `Install Goto.pkg`가 `/Applications`와 `/usr/local/bin`에 필요한 파일을 배치합니다. 프로젝트 루트에는 빌드 산출물 앱 번들을 보관하지 않습니다.
+
+Release 인스톨러 패키지는 빌드 후 다음 명령으로 생성합니다.
+
+```sh
+./scripts/build-installer.sh vX.Y.Z
+```
 
 ## 사용
 
-1. `Goto.app`을 `/Applications` 또는 `~/Applications`로 옮깁니다.
+1. `Install Goto.pkg`를 실행합니다.
 2. `Goto.app`을 실행합니다.
 3. 기본 터미널을 선택합니다. Ghostty가 설치되어 있으면 선택지에 표시됩니다.
 4. 터미널이 이미 실행 중일 때 `New Tab` 또는 `New Window` 중 하나를 선택합니다.

--- a/install.sh
+++ b/install.sh
@@ -108,10 +108,9 @@ install_to_rc() {
 echo "[4/4] 셸 함수 install"
 
 ZSH_OK=1
-BASH_OK=1
 [ -e "$HOME/.zshrc" ]  && install_to_rc "$HOME/.zshrc"  || ZSH_OK=$?
 [ "$ZSH_OK" -eq 0 ] || install_to_rc "$HOME/.zprofile" || true
-[ -e "$HOME/.bashrc" ] && install_to_rc "$HOME/.bashrc" || BASH_OK=$?
+[ -e "$HOME/.bashrc" ] && install_to_rc "$HOME/.bashrc" || true
 
 cat <<'MSG'
 

--- a/installer/components.plist
+++ b/installer/components.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+  <dict>
+    <key>RootRelativeBundlePath</key>
+    <string>Applications/Goto.app</string>
+    <key>BundleIsRelocatable</key>
+    <false/>
+    <key>BundleIsVersionChecked</key>
+    <false/>
+    <key>BundleHasStrictIdentifier</key>
+    <true/>
+    <key>BundleOverwriteAction</key>
+    <string>upgrade</string>
+  </dict>
+  <dict>
+    <key>RootRelativeBundlePath</key>
+    <string>Applications/Goto Launcher.app</string>
+    <key>BundleIsRelocatable</key>
+    <false/>
+    <key>BundleIsVersionChecked</key>
+    <false/>
+    <key>BundleHasStrictIdentifier</key>
+    <true/>
+    <key>BundleOverwriteAction</key>
+    <string>upgrade</string>
+  </dict>
+</array>
+</plist>

--- a/installer/scripts/postinstall
+++ b/installer/scripts/postinstall
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -u
+
+MARKER_BEGIN="# >>> goto cli >>>"
+MARKER_END="# <<< goto cli <<<"
+OLD_MARKER_BEGIN="# >>> goto3 cli >>>"
+OLD_MARKER_END="# <<< goto3 cli <<<"
+
+SHELL_FUNC=$(cat <<'EOF'
+# >>> goto cli >>>
+goto() {
+  if [ "$#" -gt 0 ]; then
+    /usr/local/bin/goto "$@"
+    return
+  fi
+
+  local target
+  target=$(/usr/local/bin/goto) || return
+  if [ -n "$target" ] && [ -d "$target" ]; then
+    cd "$target"
+  fi
+}
+# <<< goto cli <<<
+EOF
+)
+
+log() {
+  /bin/echo "goto installer: $*" >&2
+}
+
+remove_marker_block() {
+  local rc="$1"
+  local begin="$2"
+  local end="$3"
+
+  [ -e "$rc" ] || return 0
+  /usr/bin/grep -qF "$begin" "$rc" || return 0
+
+  local tmp
+  tmp=$(/usr/bin/mktemp "/tmp/goto-rc.XXXXXX") || return 1
+  /usr/bin/awk -v b="$begin" -v e="$end" '
+    $0 == b {skip=1; next}
+    $0 == e {skip=0; next}
+    !skip {print}
+  ' "$rc" > "$tmp" || {
+    /bin/rm -f "$tmp"
+    return 1
+  }
+  /bin/cat "$tmp" > "$rc" || {
+    /bin/rm -f "$tmp"
+    return 1
+  }
+  /bin/rm -f "$tmp"
+}
+
+clean_rc() {
+  local rc="$1"
+  [ -e "$rc" ] || return 0
+  remove_marker_block "$rc" "$OLD_MARKER_BEGIN" "$OLD_MARKER_END" || return 1
+  remove_marker_block "$rc" "$MARKER_BEGIN" "$MARKER_END" || return 1
+}
+
+install_to_rc() {
+  local rc="$1"
+  local user="$2"
+  local group="$3"
+
+  if [ ! -e "$rc" ]; then
+    /usr/bin/touch "$rc" || return 1
+    /usr/sbin/chown "$user:$group" "$rc" 2>/dev/null || true
+    /bin/chmod 0644 "$rc" 2>/dev/null || true
+  fi
+
+  clean_rc "$rc" || return 1
+  /usr/bin/printf "\n%s\n" "$SHELL_FUNC" >> "$rc" || return 1
+  /usr/sbin/chown "$user:$group" "$rc" 2>/dev/null || true
+  /bin/chmod 0644 "$rc" 2>/dev/null || true
+}
+
+console_user=$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null || true)
+case "$console_user" in
+  ""|root|loginwindow|_mbsetupuser)
+    log "no active console user; installed apps and binary only"
+    exit 0
+    ;;
+esac
+
+user_home=$(/usr/bin/dscl . -read "/Users/$console_user" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2; exit}')
+if [ -z "$user_home" ] || [ ! -d "$user_home" ]; then
+  log "cannot resolve home directory for $console_user; installed apps and binary only"
+  exit 0
+fi
+
+user_group=$(/usr/bin/id -gn "$console_user" 2>/dev/null || /bin/echo "staff")
+user_shell=$(/usr/bin/dscl . -read "/Users/$console_user" UserShell 2>/dev/null | /usr/bin/awk '{print $2; exit}')
+shell_name=$(/usr/bin/basename "${user_shell:-zsh}")
+
+for rc in "$user_home/.zshrc" "$user_home/.zprofile" "$user_home/.bashrc" "$user_home/.bash_profile"; do
+  clean_rc "$rc" || log "could not clean existing goto marker in $rc"
+done
+
+case "$shell_name" in
+  zsh)
+    target_rc="$user_home/.zshrc"
+    ;;
+  bash)
+    target_rc="$user_home/.bash_profile"
+    ;;
+  *)
+    if [ -e "$user_home/.zshrc" ]; then
+      target_rc="$user_home/.zshrc"
+    elif [ -e "$user_home/.bash_profile" ]; then
+      target_rc="$user_home/.bash_profile"
+    elif [ -e "$user_home/.bashrc" ]; then
+      target_rc="$user_home/.bashrc"
+    else
+      target_rc="$user_home/.zshrc"
+    fi
+    ;;
+esac
+
+if install_to_rc "$target_rc" "$console_user" "$user_group"; then
+  log "registered shell function in $target_rc"
+else
+  log "warning: could not register shell function in $target_rc"
+fi
+
+exit 0

--- a/installer/scripts/preinstall
+++ b/installer/scripts/preinstall
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -u
+
+# Legacy cleanup only. Current payload installs Goto.app and Goto Launcher.app.
+/bin/rm -rf \
+  "/Applications/Goto3.app" \
+  "/Applications/Goto3 Launcher.app" \
+  "/Applications/Goto3Launcher.app" \
+  "/Applications/GotoLauncher.app"
+
+exit 0

--- a/scripts/build-installer.sh
+++ b/scripts/build-installer.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export COPYFILE_DISABLE=1
+export COPY_EXTENDED_ATTRIBUTES_DISABLE=1
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  echo "usage: $0 vX.Y.Z" >&2
+  exit 64
+fi
+
+PKG_VERSION="${VERSION#v}"
+if ! [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: version must be vMAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH: $VERSION" >&2
+  exit 64
+fi
+
+BUILD_PRODUCTS_DIR="${BUILD_PRODUCTS_DIR:-./build/Build/Products/Release}"
+DIST_DIR="${DIST_DIR:-./dist}"
+PKG_ROOT="$DIST_DIR/pkg-root"
+PKG_WORK="$DIST_DIR/pkg-work"
+PKG_SCRIPTS="$PKG_WORK/scripts"
+COMPONENT_PKG="$PKG_WORK/GotoComponent.pkg"
+PRODUCT_PKG="$DIST_DIR/Goto-$VERSION.pkg"
+
+APP_SRC="$BUILD_PRODUCTS_DIR/Goto.app"
+LAUNCHER_SRC="$BUILD_PRODUCTS_DIR/GotoLauncher.app"
+CLI_SRC="$BUILD_PRODUCTS_DIR/goto"
+
+for required in "$APP_SRC" "$LAUNCHER_SRC" "$CLI_SRC"; do
+  if [ ! -e "$required" ]; then
+    echo "error: missing build artifact: $required" >&2
+    exit 66
+  fi
+done
+
+strip_appledouble_files() {
+  local package="$1"
+  local expanded="$PKG_WORK/component-expanded"
+  local payload="$PKG_WORK/payload-expanded"
+  local cleaned="$PKG_WORK/GotoComponent-clean.pkg"
+
+  rm -rf "$expanded" "$payload" "$cleaned"
+  /usr/sbin/pkgutil --expand "$package" "$expanded"
+
+  if [ -f "$expanded/Payload" ]; then
+    mkdir -p "$payload"
+    (
+      cd "$payload"
+      /usr/bin/gzip -dc "$expanded/Payload" | /usr/bin/cpio -idm 2>/dev/null
+    )
+    /usr/bin/find "$payload" -name '._*' -delete
+    payload_files=$(cd "$payload" && /usr/bin/find . -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')
+    payload_kbytes=$(/usr/bin/du -sk "$payload" | /usr/bin/awk '{print $1}')
+    /usr/bin/mkbom "$payload" "$expanded/Bom"
+    (
+      cd "$payload"
+      COPYFILE_DISABLE=1 /usr/bin/find . -print | LC_ALL=C /usr/bin/sort | /usr/bin/cpio -o --format odc 2>/dev/null | /usr/bin/gzip -c > "$expanded/Payload"
+    )
+    /usr/bin/perl -0pi -e "s/<payload numberOfFiles=\"\\d+\" installKBytes=\"\\d+\"\\/>/<payload numberOfFiles=\"$payload_files\" installKBytes=\"$payload_kbytes\"\\/>/" "$expanded/PackageInfo"
+  fi
+
+  if [ -d "$expanded/Scripts" ]; then
+    /usr/bin/find "$expanded/Scripts" -name '._*' -delete
+  fi
+
+  /usr/sbin/pkgutil --flatten "$expanded" "$cleaned"
+  /bin/mv "$cleaned" "$package"
+}
+
+rm -rf "$PKG_ROOT" "$PKG_WORK" "$PRODUCT_PKG"
+mkdir -p "$PKG_ROOT/Applications" "$PKG_ROOT/usr/local/bin" "$PKG_SCRIPTS" "$DIST_DIR"
+
+/usr/bin/ditto --noextattr --norsrc "$APP_SRC" "$PKG_ROOT/Applications/Goto.app"
+/usr/bin/ditto --noextattr --norsrc "$LAUNCHER_SRC" "$PKG_ROOT/Applications/Goto Launcher.app"
+/usr/bin/install -m 0755 "$CLI_SRC" "$PKG_ROOT/usr/local/bin/goto"
+/usr/bin/install -m 0755 "scripts/uninstall.sh" "$PKG_ROOT/usr/local/bin/goto-uninstall"
+
+for script in preinstall postinstall; do
+  /bin/cp "installer/scripts/$script" "$PKG_SCRIPTS/$script"
+  /bin/chmod 0755 "$PKG_SCRIPTS/$script"
+done
+
+/usr/bin/xattr -cr "$PKG_ROOT" "$PKG_SCRIPTS" 2>/dev/null || true
+
+/usr/bin/pkgbuild \
+  --root "$PKG_ROOT" \
+  --component-plist "installer/components.plist" \
+  --scripts "$PKG_SCRIPTS" \
+  --identifier "com.inchan.goto.pkg" \
+  --version "$PKG_VERSION" \
+  --install-location "/" \
+  "$COMPONENT_PKG"
+
+strip_appledouble_files "$COMPONENT_PKG"
+
+/usr/bin/productbuild \
+  --package "$COMPONENT_PKG" \
+  --identifier "com.inchan.goto.installer" \
+  --version "$PKG_VERSION" \
+  "$PRODUCT_PKG"
+
+echo "Built $PRODUCT_PKG"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Goto CLI installer (binary-only, used by GitHub Release zip).
+# Optional Goto CLI installer for manual binary-only installs.
+# GitHub Releases use Install Goto.pkg, which installs apps and CLI together.
 # Installs ./goto into ~/.local/bin and registers a shell function.
 set -euo pipefail
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+set -euo pipefail
+
+MARKER_BEGIN="# >>> goto cli >>>"
+MARKER_END="# <<< goto cli <<<"
+OLD_MARKER_BEGIN="# >>> goto3 cli >>>"
+OLD_MARKER_END="# <<< goto3 cli <<<"
+
+DRY_RUN=0
+PURGE=0
+ORIGINAL_ARGS=("$@")
+FAILED=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  uninstall.sh [--dry-run] [--purge]
+
+Removes Goto apps, CLI binaries, shell wrappers, and installer receipts.
+
+Options:
+  --dry-run   Print what would be removed without changing files.
+  --purge     Also remove user data and preferences:
+              ~/.goto, ~/.goto_recent, ~/.goto_pinned, ~/.goto_config,
+              Goto preferences, and Finder Sync container data.
+  --help      Show this help.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    --purge)
+      PURGE=1
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+SYSTEM_ROOT="${GOTO_UNINSTALL_SYSTEM_ROOT:-/}"
+if [ "$SYSTEM_ROOT" != "/" ]; then
+  SYSTEM_ROOT="${SYSTEM_ROOT%/}"
+fi
+
+if [ "$(id -u)" -ne 0 ] && [ "$DRY_RUN" -eq 0 ] && [ "${GOTO_UNINSTALL_SKIP_SUDO:-0}" -ne 1 ]; then
+  exec /usr/bin/sudo "$0" "${ORIGINAL_ARGS[@]}"
+fi
+
+system_path() {
+  local path="$1"
+  if [ "$SYSTEM_ROOT" = "/" ]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s%s\n' "$SYSTEM_ROOT" "$path"
+  fi
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] %q' "$1"
+    shift
+    for arg in "$@"; do
+      printf ' %q' "$arg"
+    done
+    printf '\n'
+  else
+    "$@"
+  fi
+}
+
+remove_path() {
+  local path="$1"
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    if ! run /bin/rm -rf "$path"; then
+      log "warning: failed to remove $path"
+      FAILED=1
+    fi
+  elif [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] missing: $path"
+  fi
+}
+
+remove_marker_block() {
+  local rc="$1"
+  local begin="$2"
+  local end="$3"
+
+  [ -e "$rc" ] || return 0
+  /usr/bin/grep -qF "$begin" "$rc" || return 0
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] remove marker block from $rc: $begin"
+    return 0
+  fi
+
+  local tmp
+  tmp=$(/usr/bin/mktemp "/tmp/goto-uninstall-rc.XXXXXX")
+  /usr/bin/awk -v b="$begin" -v e="$end" '
+    $0 == b {skip=1; next}
+    $0 == e {skip=0; next}
+    !skip {print}
+  ' "$rc" > "$tmp"
+  /bin/cat "$tmp" > "$rc"
+  /bin/rm -f "$tmp"
+}
+
+clean_rc() {
+  local rc="$1"
+  remove_marker_block "$rc" "$OLD_MARKER_BEGIN" "$OLD_MARKER_END"
+  remove_marker_block "$rc" "$MARKER_BEGIN" "$MARKER_END"
+}
+
+forget_receipt() {
+  local identifier="$1"
+
+  if /usr/sbin/pkgutil --pkg-info "$identifier" >/dev/null 2>&1; then
+    if ! run /usr/sbin/pkgutil --forget "$identifier" >/dev/null; then
+      log "warning: failed to forget receipt $identifier"
+      FAILED=1
+    fi
+  elif [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] receipt not found: $identifier"
+  fi
+}
+
+console_user() {
+  if [ -n "${GOTO_UNINSTALL_USER:-}" ]; then
+    printf '%s\n' "$GOTO_UNINSTALL_USER"
+    return
+  fi
+
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    printf '%s\n' "$SUDO_USER"
+    return
+  fi
+
+  /usr/bin/stat -f "%Su" /dev/console 2>/dev/null || true
+}
+
+home_for_user() {
+  local user="$1"
+
+  if [ -n "${GOTO_UNINSTALL_HOME:-}" ]; then
+    printf '%s\n' "$GOTO_UNINSTALL_HOME"
+    return
+  fi
+
+  if [ -n "$user" ]; then
+    /usr/bin/dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2; exit}'
+  fi
+}
+
+user_name="$(console_user)"
+case "$user_name" in
+  ""|root|loginwindow|_mbsetupuser)
+    user_name=""
+    ;;
+esac
+
+user_home="$(home_for_user "$user_name")"
+if [ -n "$user_home" ] && [ ! -d "$user_home" ]; then
+  user_home=""
+fi
+
+if [ "$SYSTEM_ROOT" = "/" ]; then
+  log "Stopping running Goto processes..."
+  run /usr/bin/osascript -e 'tell application id "com.inchan.goto" to quit' >/dev/null 2>&1 || true
+  run /usr/bin/pkill -x Goto >/dev/null 2>&1 || true
+  run /usr/bin/pkill -x GotoLauncher >/dev/null 2>&1 || true
+
+  if [ -n "$user_name" ]; then
+    run /usr/bin/pluginkit -e ignore -i com.inchan.goto.findersync >/dev/null 2>&1 || true
+  fi
+else
+  log "Using system root override: $SYSTEM_ROOT"
+fi
+
+log "Removing apps and CLI binaries..."
+remove_path "$(system_path "/Applications/Goto.app")"
+remove_path "$(system_path "/Applications/Goto Launcher.app")"
+remove_path "$(system_path "/Applications/GotoLauncher.app")"
+remove_path "$(system_path "/Applications/Goto3.app")"
+remove_path "$(system_path "/Applications/Goto3 Launcher.app")"
+remove_path "$(system_path "/Applications/Goto3Launcher.app")"
+remove_path "$(system_path "/usr/local/bin/goto")"
+remove_path "$(system_path "/usr/local/bin/goto-uninstall")"
+remove_path "$(system_path "/usr/local/bin/goto3")"
+remove_path "$(system_path "/usr/local/bin/goto3-uninstall")"
+
+if [ -n "$user_home" ]; then
+  log "Removing shell wrappers and legacy user-local binaries for $user_home..."
+  for rc in "$user_home/.zshrc" "$user_home/.zprofile" "$user_home/.bashrc" "$user_home/.bash_profile" "$user_home/.profile"; do
+    clean_rc "$rc"
+  done
+
+  remove_path "$user_home/.local/bin/goto"
+  remove_path "$user_home/.local/bin/goto3"
+else
+  log "No active user home found; skipped shell wrapper and user-local binary cleanup."
+fi
+
+if [ "$SYSTEM_ROOT" = "/" ]; then
+  log "Removing installer receipts..."
+  forget_receipt "com.inchan.goto.pkg"
+  forget_receipt "com.inchan.goto.installer"
+  forget_receipt "com.inchan.goto3.pkg"
+  forget_receipt "com.inchan.goto3.installer"
+else
+  log "Skipping installer receipts for system root override."
+fi
+
+if [ "$PURGE" -eq 1 ]; then
+  if [ -n "$user_home" ]; then
+    log "Purging user data and preferences..."
+    remove_path "$user_home/.goto"
+    remove_path "$user_home/.goto_recent"
+    remove_path "$user_home/.goto_pinned"
+    remove_path "$user_home/.goto_config"
+    remove_path "$user_home/Library/Preferences/com.inchan.goto.plist"
+    remove_path "$user_home/Library/Preferences/com.inchan.goto.launcher.plist"
+    remove_path "$user_home/Library/Preferences/com.inchan.goto.findersync.plist"
+    remove_path "$user_home/Library/Containers/com.inchan.goto.findersync"
+    remove_path "$user_home/Library/Application Scripts/com.inchan.goto.findersync"
+  else
+    log "No active user home found; skipped purge of user data."
+  fi
+else
+  log "User data preserved. Run with --purge to remove ~/.goto* and Goto preferences."
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+  log "Uninstall complete."
+else
+  log "Uninstall finished with warnings. Re-run with sudo if protected files remain."
+  exit 1
+fi

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -8,6 +8,7 @@
 - [[summaries/cli-prefix-features-2026-05-13]] — CLI prefix true-color badge, `f` filter mode, and shared `xxx-` pattern prefix with two new config toggles.
 - [[summaries/recent-limit-config-2026-05-15]] — make `recent` display count user-configurable (CLI + macOS app settings), bump default 3 → 5.
 - [[summaries/cli-keybindings-2026-05-19]] — CLI 키 정책 개편: 단일 문자 단축키 제거, 입력 시 자동 필터 + `Ctrl+P` 핀 / `Ctrl+Q` 종료; `ship-goto` 스킬을 `release`로 리네이밍.
+- [[summaries/installer-pkg-2026-06-16]] — Release DMG now contains one installer package that installs both apps and the CLI together.
 
 ## Concepts
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,9 @@
 # Goto Wiki Log
 
+## 2026-06-16 feat | pkg 기반 일괄 설치
+
+Release DMG의 설치 단위를 두 앱 드래그 방식에서 `Install Goto.pkg` 하나로 바꿨다. pkg payload는 `/Applications/Goto.app`, `/Applications/Goto Launcher.app`, `/usr/local/bin/goto`, `/usr/local/bin/goto-uninstall`을 함께 설치하며, postinstall에서 현재 콘솔 사용자의 zsh/bash 시작 파일에 marker 기반 `goto()` wrapper를 등록한다. 별도 `goto-cli-vX.Y.Z.zip` 릴리스 자산은 제거했다. 제거 스크립트는 현재 설치물과 legacy 앱 이름, old shell marker, 예전 `~/.local/bin/goto`까지 정리하고 `--purge` 시 사용자 데이터도 제거한다. See `summaries/installer-pkg-2026-06-16`.
+
 ## 2026-05-19 refine | CLI 키 정책 + 스킬 리네이밍
 
 CLI 인터랙티브 리스트의 단축키 정책을 **"입력 시 자동 필터"** 로 단순화했다. 단일 알파벳 단축키(`f`/`p`/`q`)를 모두 제거하고, 사용자가 임의의 printable 글자를 누르면 즉시 필터 모드로 진입하면서 그 글자가 첫 쿼리 문자로 주입된다. 핀 토글은 `Ctrl+P` (0x10), 종료는 `Ctrl+Q` (0x11) 로 옮겼으며 `ESC` / `Ctrl+C` 종료는 유지된다. macOS 터미널 raw 모드가 `Cmd+키`를 키스트로크로 전달하지 않기 때문에 `Ctrl+` 채택. `Key` enum 에 `.printable(UInt8)` associated value 케이스를 추가하면서 settings 화면의 `key == .enter` 비교를 `if case .enter = key` 패턴으로 교체했다. 같은 사이클에 출하 파이프라인 스킬 `ship-goto` 를 `deploy` 로 리네이밍 (`/deploy`, 부분 실행은 `/deploy {cleanup,docs,build,publish}`; Stage 0에서 자동/수동 모드 1회 선택). 중간 단계로 `release` 이름을 거쳤으나 `.github/workflows/release.yml` CI 명과 혼동 우려로 최종 `deploy` 채택. README CLI 사용법 한 줄과 핀 설명을 새 정책에 맞춰 갱신. See `summaries/cli-keybindings-2026-05-19`.

--- a/wiki/summaries/installer-pkg-2026-06-16.md
+++ b/wiki/summaries/installer-pkg-2026-06-16.md
@@ -1,0 +1,35 @@
+---
+tags: [release, installer, cli]
+---
+
+# Installer package release
+
+## Problem
+
+Release DMG installation required dragging both `Goto.app` and `Goto Launcher.app` into Applications, while the `goto` CLI shipped as a separate zip and was not installed with the app.
+
+## Decision
+
+Use a macOS Installer package as the single installation unit. The release DMG now contains `Install Goto.pkg` instead of two app bundles. Running the package installs:
+
+- `/Applications/Goto.app`
+- `/Applications/Goto Launcher.app`
+- `/usr/local/bin/goto`
+- `/usr/local/bin/goto-uninstall`
+- a marker-managed `goto()` shell wrapper for the active console user
+
+The shell wrapper calls `/usr/local/bin/goto` by absolute path so it is not affected by older `~/.local/bin/goto` binaries that may still be earlier in `PATH`.
+
+## Implementation
+
+- `scripts/build-installer.sh` stages a package root from Release build products and creates `dist/Goto-vX.Y.Z.pkg`.
+- `installer/components.plist` marks both app bundles as non-relocatable and uses `upgrade` overwrite behavior.
+- `installer/scripts/preinstall` removes legacy app bundle names before install.
+- `installer/scripts/postinstall` removes old/new marker blocks from common zsh/bash startup files and appends the current wrapper to the active user's shell profile.
+- `scripts/uninstall.sh` removes current app/CLI installs, old app names, old user-local CLI binaries, shell marker blocks, and package receipts. `--purge` also removes user data and preferences.
+- `.github/workflows/release.yml` builds the package, stages it into the DMG as `Install Goto.pkg`, and stops producing the separate CLI zip.
+- DMG creation uses `create-dmg --skip-jenkins` so CI does not depend on Finder AppleEvents for icon positioning.
+
+## Follow-up
+
+The package is still built with the repo's existing ad-hoc signing posture. A future notarized Developer ID flow should sign the app bundles, package, and DMG before public distribution.


### PR DESCRIPTION
## Summary
- Replace the release DMG drag-and-drop flow with a single installer package.
- Install `Goto.app`, `Goto Launcher.app`, `goto`, and `goto-uninstall` together.
- Add uninstall support for current and legacy install locations.

## Changes
- Adds `scripts/build-installer.sh` and installer package metadata/scripts.
- Updates release workflow to ship `Install Goto.pkg` and `Uninstall Goto.command` in the DMG.
- Removes the separate CLI zip from new releases.
- Documents install/uninstall behavior and records the packaging change in the wiki.

## Validation
- `bash -n scripts/uninstall.sh scripts/build-installer.sh installer/scripts/preinstall installer/scripts/postinstall scripts/install-cli.sh install.sh`
- `shellcheck scripts/uninstall.sh scripts/build-installer.sh installer/scripts/preinstall installer/scripts/postinstall scripts/install-cli.sh install.sh`
- `actionlint .github/workflows/release.yml`
- `plutil -lint installer/components.plist GotoApp/Info.plist GotoLauncher/Info.plist GotoCLI/Info.plist GotoFinderSync/Info.plist GotoFinderSync/GotoFinderSync.entitlements`
- `xcodegen generate --spec project.yml --project <tmp> --project-root <repo>`
- `swiftc` CLI compile and app/launcher/FinderSync typecheck using the CLT macOS SDK
- Dummy `pkgbuild`/`productbuild` package creation and DMG mount verification