### PR TITLE
Fix app icon refresh on install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,16 @@ jobs:
         run: xcodegen generate
 
       - name: Build Release artifacts
+        env:
+          NEXT_NO_V: ${{ steps.ver.outputs.next_no_v }}
         run: |
           set -euo pipefail
           common=(
             -project Goto.xcodeproj
             -configuration Release
             -derivedDataPath ./build
+            MARKETING_VERSION="$NEXT_NO_V"
+            CURRENT_PROJECT_VERSION="$NEXT_NO_V"
           )
           xcodebuild "${common[@]}" -scheme Goto build
           xcodebuild "${common[@]}" -scheme GotoLauncher build

--- a/GotoApp/Info.plist
+++ b/GotoApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>NSAccessibilityUsageDescription</key>

--- a/GotoCLI/Info.plist
+++ b/GotoCLI/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundleName</key>
 	<string>goto</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>
 </plist>

--- a/GotoFinderSync/Info.plist
+++ b/GotoFinderSync/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>Goto needs to control Finder and Ghostty to open the current folder in a terminal.</string>
 	<key>NSExtension</key>

--- a/GotoLauncher/Info.plist
+++ b/GotoLauncher/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/install.sh
+++ b/install.sh
@@ -16,12 +16,18 @@ fi
 
 echo "[1/4] xcodegen + xcodebuild..."
 xcodegen generate > /dev/null
-xcodebuild -project Goto.xcodeproj -scheme Goto -configuration Release \
-    -derivedDataPath ./build build > /dev/null
-xcodebuild -project Goto.xcodeproj -scheme GotoLauncher -configuration Release \
-    -derivedDataPath ./build build > /dev/null
-xcodebuild -project Goto.xcodeproj -scheme GotoCLI -configuration Release \
-    -derivedDataPath ./build build > /dev/null
+LOCAL_MARKETING_VERSION="${GOTO_VERSION:-0.0.0}"
+LOCAL_BUILD_VERSION="${GOTO_BUILD:-$(date +%Y%m%d%H%M%S)}"
+COMMON_BUILD_ARGS=(
+    -project Goto.xcodeproj
+    -configuration Release
+    -derivedDataPath ./build
+    MARKETING_VERSION="$LOCAL_MARKETING_VERSION"
+    CURRENT_PROJECT_VERSION="$LOCAL_BUILD_VERSION"
+)
+xcodebuild "${COMMON_BUILD_ARGS[@]}" -scheme Goto build > /dev/null
+xcodebuild "${COMMON_BUILD_ARGS[@]}" -scheme GotoLauncher build > /dev/null
+xcodebuild "${COMMON_BUILD_ARGS[@]}" -scheme GotoCLI build > /dev/null
 
 APP_SRC="./build/Build/Products/Release/Goto.app"
 LAUNCHER_SRC="./build/Build/Products/Release/GotoLauncher.app"
@@ -42,6 +48,12 @@ rm -rf \
     "$LAUNCHER_DST"
 cp -R "$APP_SRC" "$APP_DST"
 cp -R "$LAUNCHER_SRC" "$LAUNCHER_DST"
+
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+touch "$APP_DST" "$LAUNCHER_DST" 2>/dev/null || true
+if [ -x "$LSREGISTER" ]; then
+    "$LSREGISTER" -f "$APP_DST" "$LAUNCHER_DST" 2>/dev/null || true
+fi
 
 echo "[3/4] binary 복사: $BIN_DST"
 rm -f "$BIN_DST"

--- a/installer/scripts/postinstall
+++ b/installer/scripts/postinstall
@@ -28,6 +28,17 @@ log() {
   /bin/echo "goto installer: $*" >&2
 }
 
+refresh_app_registration() {
+  local lsregister="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+  local app="/Applications/Goto.app"
+  local launcher="/Applications/Goto Launcher.app"
+
+  /usr/bin/touch "$app" "$launcher" 2>/dev/null || true
+  if [ -x "$lsregister" ]; then
+    "$lsregister" -f "$app" "$launcher" 2>/dev/null || true
+  fi
+}
+
 remove_marker_block() {
   local rc="$1"
   local begin="$2"
@@ -76,6 +87,8 @@ install_to_rc() {
   /usr/sbin/chown "$user:$group" "$rc" 2>/dev/null || true
   /bin/chmod 0644 "$rc" 2>/dev/null || true
 }
+
+refresh_app_registration
 
 console_user=$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null || true)
 case "$console_user" in

--- a/project.yml
+++ b/project.yml
@@ -9,6 +9,8 @@ settings:
     CODE_SIGN_STYLE: Manual
     CODE_SIGN_IDENTITY: "-"
     ENABLE_USER_SCRIPT_SANDBOXING: "NO"
+    MARKETING_VERSION: "0.0.0"
+    CURRENT_PROJECT_VERSION: "0"
 targets:
   Goto:
     type: application
@@ -28,8 +30,8 @@ targets:
         CFBundleIconName: applet
         CFBundleIdentifier: com.inchan.goto
         CFBundleName: Goto
-        CFBundleShortVersionString: 1.0.0
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundleURLTypes:
           - CFBundleURLName: com.inchan.goto.worktree
             CFBundleURLSchemes:
@@ -61,8 +63,8 @@ targets:
         CFBundleIconName: applet
         CFBundleIdentifier: com.inchan.goto.launcher
         CFBundleName: GotoLauncher
-        CFBundleShortVersionString: 1.0.0
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         CFBundleURLTypes:
           - CFBundleURLName: com.inchan.goto.launcher
             CFBundleURLSchemes:
@@ -87,8 +89,8 @@ targets:
       properties:
         CFBundleIdentifier: com.inchan.goto.cli
         CFBundleName: goto
-        CFBundleShortVersionString: 1.0.0
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.inchan.goto.cli
@@ -115,8 +117,8 @@ targets:
         CFBundleDisplayName: Goto Finder Extension
         CFBundleIdentifier: com.inchan.goto.findersync
         CFBundleName: GotoFinderSync
-        CFBundleShortVersionString: 1.0.0
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSAppleEventsUsageDescription: Goto needs to control Finder and Ghostty to open the current folder in a terminal.
         NSExtension:
           NSExtensionPointIdentifier: com.apple.FinderSync


### PR DESCRIPTION
## Summary

- Stamp all app/extension/CLI bundles with build settings instead of fixed `1.0.0` / `1` versions.
- Pass the release tag version into Xcode builds so installed apps have a new bundle version each release.
- Refresh LaunchServices registration after local installs and installer package installs so Finder/Dock app icons can pick up changed `.icns` resources.

## Why

The new Terminal Frame Stack resources were present in `Resources/applet.icns` and installed app bundles, while the menu bar glyph updated correctly. Finder/Dock app icons could still show stale artwork because the app bundles kept the same `CFBundleShortVersionString=1.0.0` and `CFBundleVersion=1`, and installer postinstall did not re-register the apps with LaunchServices.

## Validation

- Confirmed installed `/Applications/Goto.app` and `/Applications/Goto Launcher.app` already contained the new `applet.icns` hash.
- Ran `xcodegen generate` and confirmed generated plist values now use `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`.
- Ran `plutil -lint` for all app/extension/CLI Info.plists.
- Ran shell syntax checks for `install.sh`, `installer/scripts/postinstall`, and `scripts/build-installer.sh`.
- Parsed `.github/workflows/release.yml` as YAML.

Local `xcodebuild` could not run on this machine because only Command Line Tools are installed and `/Applications/Xcode.app` is not present; the release workflow uses Xcode on macOS Actions and will validate the full build.